### PR TITLE
:bug: fix docker image using wrong jar

### DIFF
--- a/dispatch-service/Dockerfile
+++ b/dispatch-service/Dockerfile
@@ -2,4 +2,4 @@
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 
 # Copy runnable jar to deployments
-COPY target/*.jar /deployments/application.jar
+COPY target/dispatch-service-*.jar /deployments/application.jar

--- a/matching-service/Dockerfile
+++ b/matching-service/Dockerfile
@@ -2,4 +2,4 @@
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 
 # Copy runnable jar to deployments
-COPY target/*.jar /deployments/application.jar
+COPY target/matching-service-*.jar /deployments/application.jar


### PR DESCRIPTION
**Description**

Fix image build using wrong jar. In this case `findsecbugs` jar was used and not the dispatch-service image.
Think that wasn't occurring for other packages, based of the ordering by filename.

![image](https://github.com/user-attachments/assets/5f81ee57-bf68-4090-ac1a-095c1ed74d5f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfiles for `dispatch-service` and `matching-service` to use more specific JAR file copying patterns during deployment.
	- Improved artifact selection to ensure only intended service JAR files are copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->