### PR TITLE
:wrench: renovate disable pr module splitting

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "additionalBranchPrefix": "",
   "extends": [
     "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5",
   ]


### PR DESCRIPTION
**Description**

Disable Renovate separate PRs per modules by removing branch prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Renovate configuration to include an additional branch prefix setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->