### PR TITLE
Bug/ci fix release module version bump

### DIFF
--- a/.github/actions/release-maven/action.yaml
+++ b/.github/actions/release-maven/action.yaml
@@ -65,18 +65,18 @@ runs:
     - name: Push changes to new branch
       shell: bash
       run: |
-        git checkout -b ${{ github.ref_name }}-version-bump
-        git push --force origin ${{ github.ref_name }}-version-bump
+        git checkout -b ${{ github.module }}-version-bump
+        git push --force origin ${{ github.module }}-version-bump
     - name: Create pull request
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const { repo, owner } = context.repo;
           const pullResult = await github.rest.pulls.create({
-            title: 'chore: bump release version ${{ github.ref_name }}',
+            title: 'chore: bump release version ${{ github.module }}',
             owner,
             repo,
-            head: '${{ github.ref_name }}-version-bump',
+            head: '${{ github.module }}-version-bump',
             base: '${{ github.ref_name }}',
             body: [
               'This PR is auto-generated'


### PR DESCRIPTION
**Description**

Fix release CI that version bump of different modules can be open in parallel.
Currently the same branch name is used for all modules which breaks parallel releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions release workflow for Maven projects
	- Modified branch naming and pull request title generation logic
	- Aligned branch and PR title with module-specific versioning
<!-- end of auto-generated comment: release notes by coderabbit.ai -->