### PR TITLE
Refact/dispatch s3 file listing

### DIFF
--- a/dispatch-service/pom.xml
+++ b/dispatch-service/pom.xml
@@ -6,12 +6,12 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.0</version>
-        <relativePath/>
+        <relativePath />
     </parent>
 
     <groupId>de.muenchen.oss.swim</groupId>
     <artifactId>dispatch-service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <name>dispatch-service</name>
     <description>SWIM service for notifying other services (i.e. DMS) that a file is ready for further processing via Kafka</description>
     <url>https://github.com/it-at-m/swim</url>

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -207,7 +207,7 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
     }
 
     @Override
-    public void moveFile(String bucket, String srcPath, String destPath) {
+    public void moveFile(final String bucket, final String srcPath, final String destPath) {
         try {
             // copy file
             final CopySource copySource = CopySource.builder()

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -96,6 +96,16 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
     }
 
     @Override
+    public List<String> getSubDirectories(final String bucket, final String pathPrefix) {
+        // ensure prefix is handled as specific dir
+        final String escapedPathPrefix = pathPrefix.endsWith("/") ? pathPrefix : pathPrefix + "/";
+        // build s3 list request
+        return this.getObjectsInPath(bucket, escapedPathPrefix, false).stream()
+                .filter(Item::isDir)
+                .map(Item::objectName).toList();
+    }
+
+    @Override
     public void tagFile(final String bucket, final String path, final Map<String, String> tags) {
         // get current tags
         final Map<String, String> currentTags = getTagsOfFile(bucket, path);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
@@ -84,4 +84,13 @@ public interface FileSystemOutPort {
      * @param presignedUrl The presigned url.
      */
     boolean verifyPresignedUrl(@NotBlank String presignedUrl) throws PresignedUrlException;
+
+    /**
+     * Move a file from one place to another.
+     *
+     * @param bucket The bucket the file is in.
+     * @param srcPath The source path of the file.
+     * @param destPath The destination path of the file.
+     */
+    void moveFile(@NotBlank String bucket, @NotBlank String srcPath, @NotBlank String destPath);
 }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
@@ -31,6 +31,18 @@ public interface FileSystemOutPort {
             @NotNull Map<String, List<String>> excludeTags);
 
     /**
+     * Get names of subdirectories.
+     *
+     * @param bucket The bucket to look in.
+     * @param pathPrefix The path to look under.
+     * @return The names of the subdirectories.
+     */
+    List<String> getSubDirectories(
+            @NotBlank String bucket,
+            @NotNull String pathPrefix
+    );
+
+    /**
      * Add tags to a file.
      *
      * @param bucket The bucket the file is in.

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/port/out/FileSystemOutPort.java
@@ -39,8 +39,7 @@ public interface FileSystemOutPort {
      */
     List<String> getSubDirectories(
             @NotBlank String bucket,
-            @NotNull String pathPrefix
-    );
+            @NotNull String pathPrefix);
 
     /**
      * Add tags to a file.

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCase.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCase.java
@@ -68,7 +68,8 @@ public class DispatcherUserCase implements DispatcherInPort {
      * @param folder The full path of the folder.
      * @return Error which occurred during processing (Key: file path, value: error).
      */
-    private @NotNull Map<String, Throwable> processDirectory(final UseCase useCase, final String folder) {
+    private @NotNull
+    Map<String, Throwable> processDirectory(final UseCase useCase, final String folder) {
         final List<File> readyFiles = fileSystemOutPort.getMatchingFiles(
                 useCase.getBucket(),
                 folder,

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCase.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCase.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -42,29 +43,13 @@ public class DispatcherUserCase implements DispatcherInPort {
     public void triggerDispatching() {
         log.info("Starting dispatching");
         for (final UseCase useCase : swimDispatcherProperties.getUseCases()) {
-            // get files ready for dispatching
-            final List<File> readyFiles = fileSystemOutPort.getMatchingFiles(
-                    useCase.getBucket(),
-                    useCase.getPath(),
-                    useCase.isRecursive(),
-                    FILE_EXTENSION_PDF,
-                    useCase.getRequiredTags(),
-                    swimDispatcherProperties.getDispatchExcludeTags());
-            // for each file
-            log.info("Found {} ready to process files for use case {}", readyFiles.size(), useCase.getName());
+            // get folders
+            final List<String> folders = fileSystemOutPort.getSubDirectories(useCase.getBucket(), useCase.getPath());
+            // dispatch files per folder if not in finished folder
             final Map<String, Throwable> errors = new HashMap<>();
-            for (final File file : readyFiles) {
-                if (!useCase.isSensitiveFilename()) {
-                    log.info("Processing file {} for use case {}", file.path(), useCase.getName());
-                }
-                try {
-                    this.processFile(useCase, file);
-                } catch (final MetadataException | FileSizeException e) {
-                    log.warn("Error while processing file {} for use case {}", file.path(), useCase.getName(), e);
-                    // mark file as failed
-                    markFileError(file, swimDispatcherProperties.getDispatchStateTagKey(), e);
-                    // store exception for later notification
-                    errors.put(file.path(), e);
+            for (final String folder : folders) {
+                if (!folder.contains(swimDispatcherProperties.getFinishedFolder())) {
+                    errors.putAll(this.processDirectory(useCase, folder));
                 }
             }
             // send errors
@@ -73,6 +58,42 @@ public class DispatcherUserCase implements DispatcherInPort {
             }
         }
         log.info("Finished dispatching");
+    }
+
+    /**
+     * Process all files inside a folder recursively.
+     * See {@link DispatcherUserCase#processFile(UseCase, File)}.
+     *
+     * @param useCase The bucket of the folder.
+     * @param folder The full path of the folder.
+     * @return Error which occurred during processing (Key: file path, value: error).
+     */
+    private @NotNull Map<String, Throwable> processDirectory(final UseCase useCase, final String folder) {
+        final List<File> readyFiles = fileSystemOutPort.getMatchingFiles(
+                useCase.getBucket(),
+                folder,
+                useCase.isRecursive(),
+                FILE_EXTENSION_PDF,
+                useCase.getRequiredTags(),
+                swimDispatcherProperties.getDispatchExcludeTags());
+        // for each file
+        log.info("Found {} ready to process files for use case {} in folder {}", readyFiles.size(), useCase.getName(), folder);
+        final Map<String, Throwable> errors = new HashMap<>();
+        for (final File file : readyFiles) {
+            if (!useCase.isSensitiveFilename()) {
+                log.info("Processing file {} for use case {}", file.path(), useCase.getName());
+            }
+            try {
+                this.processFile(useCase, file);
+            } catch (final MetadataException | FileSizeException e) {
+                log.warn("Error while processing file {} for use case {}", file.path(), useCase.getName(), e);
+                // mark file as failed
+                markFileError(file, swimDispatcherProperties.getDispatchStateTagKey(), e);
+                // store exception for later notification
+                errors.put(file.path(), e);
+            }
+        }
+        return errors;
     }
 
     /**

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCase.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCase.java
@@ -34,7 +34,8 @@ public class MarkFileFinishedUseCase implements MarkFileFinishedInPort {
                 swimDispatcherProperties.getDispatchStateTagKey(), swimDispatcherProperties.getDispatchFileFinishedTagValue()));
         // move file
         final String useCasePath = useCase.getPath().endsWith("/") ? useCase.getPath() : useCase.getPath() + "/";
-        final String finishedFolder = swimDispatcherProperties.getFinishedFolder().endsWith("/") ? swimDispatcherProperties.getFinishedFolder() : swimDispatcherProperties.getFinishedFolder() + "/";
+        final String finishedFolder = swimDispatcherProperties.getFinishedFolder().endsWith("/") ? swimDispatcherProperties.getFinishedFolder()
+                : swimDispatcherProperties.getFinishedFolder() + "/";
         final String destPath = file.path().replace(useCasePath, String.format("%s%s", useCasePath, finishedFolder));
         fileSystemOutPort.moveFile(file.bucket(), file.path(), destPath);
         log.info("Finished file {} in use case {}", file.path(), useCaseName);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCase.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCase.java
@@ -6,6 +6,7 @@ import de.muenchen.oss.swim.dispatcher.configuration.SwimDispatcherProperties;
 import de.muenchen.oss.swim.dispatcher.domain.exception.PresignedUrlException;
 import de.muenchen.oss.swim.dispatcher.domain.exception.UseCaseException;
 import de.muenchen.oss.swim.dispatcher.domain.model.File;
+import de.muenchen.oss.swim.dispatcher.domain.model.UseCase;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ public class MarkFileFinishedUseCase implements MarkFileFinishedInPort {
     @Override
     public void markFileFinished(final String useCaseName, final String presignedUrl) throws PresignedUrlException, UseCaseException {
         // resolve usecase from name
-        this.swimDispatcherProperties.findUseCase(useCaseName);
+        final UseCase useCase = this.swimDispatcherProperties.findUseCase(useCaseName);
         // verify presigned url
         if (!fileSystemOutPort.verifyPresignedUrl(presignedUrl)) {
             throw new PresignedUrlException("Presigned url not valid");
@@ -31,6 +32,11 @@ public class MarkFileFinishedUseCase implements MarkFileFinishedInPort {
         // tag file as finished
         fileSystemOutPort.tagFile(file.bucket(), file.path(), Map.of(
                 swimDispatcherProperties.getDispatchStateTagKey(), swimDispatcherProperties.getDispatchFileFinishedTagValue()));
-        log.info("Marked file {} in use case {} as finished", file.path(), useCaseName);
+        // move file
+        final String useCasePath = useCase.getPath().endsWith("/") ? useCase.getPath() : useCase.getPath() + "/";
+        final String finishedFolder = swimDispatcherProperties.getFinishedFolder().endsWith("/") ? swimDispatcherProperties.getFinishedFolder() : swimDispatcherProperties.getFinishedFolder() + "/";
+        final String destPath = file.path().replace(useCasePath, String.format("%s%s", useCasePath, finishedFolder));
+        fileSystemOutPort.moveFile(file.bucket(), file.path(), destPath);
+        log.info("Finished file {} in use case {}", file.path(), useCaseName);
     }
 }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/configuration/SwimDispatcherProperties.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/configuration/SwimDispatcherProperties.java
@@ -14,7 +14,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "swim")
 @Validated
 public class SwimDispatcherProperties {
-    // tag keys
+    // ########### tag keys ###########
     /**
      * Tag key used for dispatching file state.
      */
@@ -35,7 +35,7 @@ public class SwimDispatcherProperties {
      */
     @NotBlank
     private String errorMessageTagKey;
-    // tag values
+    // ########### tag values ###########
     /**
      * Tag value for successfully dispatched files.
      */
@@ -56,18 +56,30 @@ public class SwimDispatcherProperties {
      */
     @NotBlank
     private String errorStateValue = "error";
-    // use cases
+    // ########### use cases ###########
+    /**
+     * Use cases which are processed.
+     */
     @NotEmpty
     private List<UseCase> useCases = List.of();
-    // mail
+    // ########### additional attributes ###########
+    /**
+     * Fallback mail address for notifications.
+     * Is used when no recipients can be resolved via use case.
+     */
     @NotEmpty
     private String fallbackMail;
-    // max file size
     /**
      * Max size files can have that they are dispatched.
      * Default: 100MiB
      */
     private Long maxFileSize = 100 * 1024 * 1024L;
+    /**
+     * Folder name where finished files are moved to.
+     * Folder paths which contain this sequence are ignored from dispatching.
+     */
+    @NotBlank
+    private String finishedFolder = "_finished";
 
     /**
      * Default tags which are excluded when looking up files for dispatching.

--- a/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCaseTest.java
+++ b/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUserCaseTest.java
@@ -62,7 +62,8 @@ class DispatcherUserCaseTest {
 
     private static final String USE_CASE = "test-meta";
     private static final List<String> USE_CASE_RECIPIENTS = List.of("test-meta@example.com");
-    private static final String PATH_PREFIX = "test";
+    private static final String USE_CASE_PATH = "test";
+    private static final String FOLDER_PATH = "test/path/";
     private static final File FILE1 = new File(BUCKET, "test/path/test.pdf", 0L);
     private static final File FILE2 = new File(BUCKET, "test/path/test2.pdf", 0L);
 
@@ -72,7 +73,8 @@ class DispatcherUserCaseTest {
         void testTriggerDispatching_Success() throws FileSizeException, MetadataException {
             // setup
             final UseCase useCase = swimDispatcherProperties.getUseCases().getFirst();
-            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(PATH_PREFIX), eq(true), eq("pdf"), anyMap(), anyMap())).thenReturn(List.of(FILE1, FILE2));
+            when(fileSystemOutPort.getSubDirectories(eq(BUCKET), eq(USE_CASE_PATH))).thenReturn(List.of(FOLDER_PATH));
+            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(FOLDER_PATH), eq(true), eq("pdf"), anyMap(), anyMap())).thenReturn(List.of(FILE1, FILE2));
             doNothing().when(dispatcherUserCase).processFile(any(), any());
             // call
             dispatcherUserCase.triggerDispatching();
@@ -87,7 +89,8 @@ class DispatcherUserCaseTest {
         void testTriggerDispatching_Exception() throws FileSizeException, MetadataException {
             // setup
             final UseCase useCase = swimDispatcherProperties.getUseCases().getFirst();
-            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(PATH_PREFIX), eq(true), eq("pdf"), anyMap(), anyMap())).thenReturn(List.of(FILE1, FILE2));
+            when(fileSystemOutPort.getSubDirectories(eq(BUCKET), eq(USE_CASE_PATH))).thenReturn(List.of(FOLDER_PATH));
+            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(FOLDER_PATH), eq(true), eq("pdf"), anyMap(), anyMap())).thenReturn(List.of(FILE1, FILE2));
             final FileSizeException e = new FileSizeException("Error");
             doThrow(e).when(dispatcherUserCase).processFile(any(), any());
             // call
@@ -143,7 +146,7 @@ class DispatcherUserCaseTest {
         @Test
         void testTriggerProtocolProcessing_Successful() {
             // setup
-            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(PATH_PREFIX), eq(true), eq("csv"), anyMap(), anyMap())).thenReturn(List.of(
+            when(fileSystemOutPort.getMatchingFiles(eq(BUCKET), eq(USE_CASE_PATH), eq(true), eq("csv"), anyMap(), anyMap())).thenReturn(List.of(
                     PROTOCOL_FILE,
                     NO_PROTOCOL_FILE));
             doNothing().when(dispatcherUserCase).processProtocolFile(any(), any());

--- a/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCaseTest.java
+++ b/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/MarkFileFinishedUseCaseTest.java
@@ -43,6 +43,7 @@ class MarkFileFinishedUseCaseTest {
         verify(fileSystemOutPort, times(1)).verifyPresignedUrl(TEST_PRESIGNED_URL);
         verify(fileSystemOutPort, times(1)).tagFile(eq("test-bucket"), eq("test/path/example.pdf"), eq(Map.of(
                 "SWIM_State", "finished")));
+        verify(fileSystemOutPort, times(1)).moveFile(eq("test-bucket"), eq("test/path/example.pdf"), eq("test/_finished/path/example.pdf"));
     }
 
     @Test


### PR DESCRIPTION
**Description**

Process use case subdirectory wise and move file to ignored finished directory.

**Reference**

Workaround solution for issue #64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added capability to retrieve subdirectories in the file system.
  - Introduced file movement functionality within S3 storage.
  - Enhanced dispatcher service with new directory processing logic.

- **Version Update**
  - Incremented dispatch service version from `0.0.1-SNAPSHOT` to `0.2.0-SNAPSHOT`.

- **Improvements**
  - Updated file handling and processing methods.
  - Enhanced documentation and organization of configuration properties.
  - Improved clarity in error handling for file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->