### PR TITLE
:bug: dispatch and dms fix kafka timeout and duplicate consume

### DIFF
--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       default:
         consumer:
           max-attempts: 3
+          ack-mode: record
       kafka:
         binder:
           auto-create-topics: false
@@ -15,6 +16,9 @@ spring:
             key:
               serializer: org.springframework.kafka.support.serializer.JsonSerializer
           consumerProperties:
+            max:
+              poll:
+                records: 20
             auto:
               offset:
                 reset: latest

--- a/dms-service/src/main/resources/application.yml
+++ b/dms-service/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       default:
         consumer:
           max-attempts: 3
+          ack-mode: record
       kafka:
         binder:
           auto-create-topics: false
@@ -15,6 +16,9 @@ spring:
             key:
               serializer: org.springframework.kafka.support.serializer.JsonSerializer
           consumerProperties:
+            max:
+              poll:
+                records: 20
             auto:
               offset:
                 reset: latest


### PR DESCRIPTION
**Description**

Fix Kafka timing out, reassigning partitions and therefore reprocesses already finished messages, which lead to errors.

In the real test i used the following values, but in my opinion, this here should work exactly the same.

![grafik](https://github.com/user-attachments/assets/5f7c169a-5f8a-412c-82bf-acf54651182f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined Kafka consumer configurations to enhance message acknowledgment handling and control data polling rates for improved overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->