### PR TITLE
bug/handler-core add AutoConfiguration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,3 +21,6 @@
 "Component: DMS":
   - changed-files:
     - any-glob-to-any-file: [ 'dms-service/**' ]
+"Component: Handler-Core":
+  - changed-files:
+      - any-glob-to-any-file: [ 'handler-core/**' ]

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/HandlerCoreAutoConfiguration.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/HandlerCoreAutoConfiguration.java
@@ -1,0 +1,9 @@
+package de.muenchen.oss.swim.libs.handlercore;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@AutoConfiguration
+@ComponentScan
+public class HandlerCoreAutoConfiguration {
+}

--- a/handler-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/handler-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.muenchen.oss.swim.libs.handlercore.HandlerCoreAutoConfiguration


### PR DESCRIPTION
**Description**

Handler-core add missing AutoConfiguration.

**Reference**

Issues #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced auto-configuration capability that streamlines the setup and integration of application components in Spring Boot deployments, ensuring smoother and more reliable initialization without manual adjustments.
	- Added a new component entry for "Handler-Core" to improve labeling functionality in the GitHub workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->