### PR TITLE
bug/fix kafka ack mode

### DIFF
--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -6,8 +6,10 @@ spring:
       default:
         consumer:
           max-attempts: 3
-          ack-mode: record
       kafka:
+        default:
+          consumer:
+            ack-mode: record
         binder:
           auto-create-topics: false
           producerProperties:

--- a/dms-service/src/main/resources/application.yml
+++ b/dms-service/src/main/resources/application.yml
@@ -6,8 +6,10 @@ spring:
       default:
         consumer:
           max-attempts: 3
-          ack-mode: record
       kafka:
+        default:
+          consumer:
+            ack-mode: record
         binder:
           auto-create-topics: false
           producerProperties:


### PR DESCRIPTION
**Description**

Fix kafka consumers `ack-mode: record` not working. 
See https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream-binder-kafka.html#kafka-consumer-properties which references the new key `spring.cloud.stream.kafka.default.consumer.<property>=<value>` should work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reorganized the messaging service’s consumer acknowledgment settings to enhance clarity and maintainability without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->