### PR TITLE
maint/matching stack add pg admin

### DIFF
--- a/dispatch-service/stack/docker-compose.yml
+++ b/dispatch-service/stack/docker-compose.yml
@@ -1,6 +1,9 @@
 name: swim-stack
 
 services:
+  #
+  # ============= DB =============
+  #
   postgres:
     image: postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c
     environment:
@@ -43,7 +46,9 @@ services:
     user: root # see https://github.com/pgadmin-org/pgadmin4/issues/6257
     entrypoint: /bin/sh -c "chmod 600 /pgadmin4/pgpass; /entrypoint.sh;" # see https://www.postgresql.org/docs/current/libpq-pgpass.html#LIBPQ-PGPASS (last paragraph)
 
-  # === Kafka ===
+  #
+  # ============= Kafka =============
+  #
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:
@@ -125,7 +130,9 @@ services:
       "
     security_opt: *security_settings
 
-  # === S3/Minio ===
+  #
+  # ============= S3 =============
+  #
   minio:
     image: quay.io/minio/minio:latest
     command: server /data --console-address ":9001"
@@ -158,7 +165,9 @@ services:
       - internal
     security_opt: *security_settings
 
-  # === Mail ===
+  #
+  # ============= Mail =============
+  #
   mailpit:
     image: axllent/mailpit:v1.20.6@sha256:777080b355ef30e99b23007e4d043b452cf84fd4dcb378ef30da5a0aa316c33d
     ports:

--- a/matching-service/README.md
+++ b/matching-service/README.md
@@ -30,5 +30,7 @@ flowchart LR
   - Can be started with `docker compose up -d`
 - The Spring profile `local` is preconfigured for using the stack
   - Activate it either manually or by using the provided run configuration
-- After starting the application the import can be triggered via the [Swagger-UI](http://localhost:39146/swagger-ui/index.html)
+- After starting the application, the import can be triggered via the [Swagger-UI](http://localhost:39146/swagger-ui/index.html)
   - The default login is `user` with password `user`
+- Also following tools are available:
+  - [pgAdmin](http://localhost:5050/)

--- a/matching-service/stack/docker-compose.yml
+++ b/matching-service/stack/docker-compose.yml
@@ -1,6 +1,9 @@
 name: swim-matching-stack
 
 services:
+  #
+  # ============= DB =============
+  #
   postgres:
     image: postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c
     environment:
@@ -20,6 +23,32 @@ services:
     security_opt: &security_settings
       - no-new-privileges:true
 
+  # see https://event-driven.io/en/automatically_connect_pgadmin_to_database/
+  pg-admin:
+    image: dpage/pgadmin4:8.14@sha256:8a68677a97b8c8d1427dc915672a26d2c4a04376916a68256f53d669d6171be7
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@admin.com
+      - PGADMIN_DEFAULT_PASSWORD=admin
+      - PGADMIN_CONFIG_SERVER_MODE=False
+      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+      - PGADMIN_LISTEN_PORT=5050
+    ports:
+      - "5050:5050"
+    depends_on:
+      - postgres
+    healthcheck:
+      <<: *healthcheck
+      test: ["CMD", "wget", "-O", "-", "http://localhost:5050/misc/ping"]
+    security_opt: *security_settings
+    volumes:
+      - './pgadmin/servers.json:/pgadmin4/servers.json:ro'
+      - './pgadmin/pgpass:/pgadmin4/pgpass'
+    user: root # see https://github.com/pgadmin-org/pgadmin4/issues/6257
+    entrypoint: /bin/sh -c "chmod 600 /pgadmin4/pgpass; /entrypoint.sh;" # see https://www.postgresql.org/docs/current/libpq-pgpass.html#LIBPQ-PGPASS (last paragraph)
+
+  #
+  # ============= Keycloak =============
+  #
   keycloak:
     image: quay.io/keycloak/keycloak:20.0.5@sha256:054ef67eb7dae0129bbb9eb0e0797fd2392cd6d135094a6063ae7ff7773ef81f
     command:

--- a/matching-service/stack/pgadmin/pgpass
+++ b/matching-service/stack/pgadmin/pgpass
@@ -1,0 +1,1 @@
+postgres:5432:*:admin:admin

--- a/matching-service/stack/pgadmin/servers.json
+++ b/matching-service/stack/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "Postgres Docker",
+      "Group": "Servers",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "postgres",
+      "Username": "admin",
+      "PassFile": "/pgadmin4/pgpass",
+      "SSLMode": "prefer"
+    }
+  }
+}


### PR DESCRIPTION
**Description**

Add pgAdmin to matching-service dev stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a web-based management interface for PostgreSQL, empowering users with enhanced database oversight through pgAdmin with default credentials, persistent storage, and health-check monitoring.
  - Added server configuration for pgAdmin to connect to PostgreSQL with specified settings.

- **Chore**
  - Refined internal configuration sections for improved clarity and maintainability without affecting service functionality.
  - Updated README to include pgAdmin as an available tool and made minor grammatical adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->