### PR TITLE
feat/dms target type via metadata file

### DIFF
--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -89,14 +89,14 @@ Example:
 
 ### Type
 
-The `type` attribute of a use case defines what type of ressource is created in the DMS.
+The `type` attribute of a use case defines what type of resource is created in the DMS.
 
 - `inbox`: Creates an ContentObject inside a given Inbox.
 - `incoming_object`: Creates an Incoming (with a ContentObject) inside a given Procedure or the OU work queue of the user.
 
 ### Coo source
 
-The `coo-source` attribute of a use case defines how the target ressource, under which the new ressource is created, is resolved.
+The `coo-source` attribute of a use case defines how the target resource, under which the new ressource is created, is resolved.
 
 - `metadata_file`: The target coo and username are resolved via a separate metadata file, which is placed beside the original file in the S3. See [Metadata file](#metadata-file).
 - `static`: The target coo is defined statically via the `target-coo` use case attribute.

--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -49,6 +49,17 @@ swim:
     base-url:
     username:
     password:
+  # metadata keys (default values)
+  metadata-subject-prefix: "FdE_" # prefix to build subject from metadata file, see Metadata
+  metadata-dms-target-key: "SWIM_DMS_Target" # key to use for resolving dms target type, see Type metadata_file
+  metadata-user-inbox-coo-key: "PPK_COO" # key to use for resolving target user inbox, see Coo source metadata_file and Metadata
+  metadata-user-inbox-user-key: "PPK_Username"
+  metadata-group-inbox-coo-key: "GPK_COO" # key to use for resolving target group inbox, see Coo source metadata_file and Metadata
+  metadata-group-inbox-user-key: "GPK_Username"
+  metadata-incoming-coo-key: "VG_COO" # key to use for resolving target incoming, see Coo source metadata_file and Metadata
+  metadata-incoming-user-key: "VG_Username"
+  metadata-incoming-joboe-key: "VG_Joboe"
+  metadata-incoming-jobposition-key: "VG_Jobposition"
   # use cases
   use-cases:
     - name: # required
@@ -94,6 +105,7 @@ The `type` attribute of a use case defines what type of resource is created in t
 
 - `inbox`: Creates an ContentObject inside a given Inbox.
 - `incoming_object`: Creates an Incoming (with a ContentObject) inside a given Procedure or the OU work queue of the user.
+- `metadata_file`: Resolve target type via metadata file. See [Configuration](#configuration) `metadata-dms-target-key` and [Metadata file](#metadata-file).
 
 ### Coo source
 
@@ -107,17 +119,28 @@ The `coo-source` attribute of a use case defines how the target resource, under 
 
 #### Metadata file
 
-The metadata file needs to have the following syntax.
-A valid metadata file either has personal `PPK_` or group `GPK_` inbox values defined (empty values are ignored).
-If a metadata file is required but missing or is invalid (syntax, value combination, ...) an Exception is thrown, which is handled by the [error-handling](#error-handling).
+The metadata file is used for following different functions:
 
-Beside the usage of the metadata file as coo source (`coo-source: metadata_file`), values starting with `PdE_` (default) could be set as subject (see [Configuration](#configuration) `metadata-subject: true`).
-The below example would lead to a subject `ExampleKey1: Example Value 1\nExampleKey2: Example Value 2`.
+- Resolution of coo source
+    - The dms target can be resolved via metadata file, see [Coo source](#coo-source) `metadata_file`
+    - A valid metadata file in this case requires either personal `PPK_` or group `GPK_` inbox values defined (empty values are ignored) for `type: inbox` or `VG_` values for incoming or coo work queue. See [Configuration](#configuration).
+- Subject
+  - Values starting with `PdE_` (default) could be set as subject (see [Configuration](#configuration) `metadata-subject: true` and `metadata-subject-prefix`).
+  - The below example would lead to a subject `ExampleKey1: Example Value 1\nExampleKey2: Example Value 2`.
+- Target type
+  - The target resource type is resolved via metadata file. See [Configuration](#configuration) `metadata-dms-target-key` and [Type](#type) `metadata_file`.
+  - Allowed values in metadata file are `inbox` and `incoming`.
+
+If a metadata file is required but missing or is invalid (syntax, value combination, ...) an Exception is thrown, which is handled by the [error-handling](#error-handling).
 
 ```json
 {
   "Document": {
     "IndexFields": [
+      {
+        "Name": "SWIM_DMS_Target",
+        "Value": "<inbox/incoming>"
+      },
       {
         "Name": "PPK_COO",
         "Value": ""
@@ -132,6 +155,22 @@ The below example would lead to a subject `ExampleKey1: Example Value 1\nExample
       },
       {
         "Name": "GPK_Username",
+        "Value": ""
+      },
+      {
+        "Name": "VG_COO",
+        "Value": ""
+      },
+      {
+        "Name": "VG_Username",
+        "Value": ""
+      },
+      {
+        "Name": "VG_Joboe",
+        "Value": ""
+      },
+      {
+        "Name": "VG_Jobposition",
         "Value": ""
       },
       {

--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -36,7 +36,7 @@
         <itm-java-codeformat.version>1.0.10</itm-java-codeformat.version>
         <pmd-maven-plugin.version>3.26.0</pmd-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.1.0</spotbugs-maven-plugin.version>
-        <spotbugs-annotations.version>4.9.1</spotbugs-annotations.version>
+        <spotbugs-annotations.version>4.9.1</spotbugs-annotations.version> <!-- must match the patch version of spotbugs-maven-plugin -->
         <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
 
         <!-- Testing -->

--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -26,7 +26,7 @@
         <!-- Core Frameworks -->
         <spring-cloud-dependencies.version>2024.0.0</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
         <refarch-dms-integration-fabasoft-rest-api.version>1.3.1</refarch-dms-integration-fabasoft-rest-api.version>
-        <swim-handler-core.version>0.1.1</swim-handler-core.version>
+        <swim-handler-core.version>0.2.0</swim-handler-core.version>
 
         <!-- Logging -->
         <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -101,10 +101,13 @@ public class ProcessFileUseCase implements ProcessFileInPort {
      */
     protected void processIncoming(final File file, final UseCase useCase, final DmsTarget dmsTarget, final String contentObjectName,
             final InputStream fileStream, final JsonNode metadataJson) throws MetadataException {
+        final String contentObjectNameWithoutExtension = contentObjectName.substring(0, contentObjectName.lastIndexOf('.'));
+        final String filename = file.getFileName();
+        final String filenameWithoutExtension = filename.substring(0, filename.lastIndexOf('.'));
         // check target procedure name
         if (Strings.isNotBlank(useCase.getVerifyProcedureNamePattern())) {
             final String procedureName = this.dmsOutPort.getProcedureName(dmsTarget);
-            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getVerifyProcedureNamePattern(), file.getFileName(), metadataJson);
+            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getVerifyProcedureNamePattern(), filenameWithoutExtension, metadataJson);
             if (!procedureName.toLowerCase(Locale.ROOT).contains(resolvedPattern.toLowerCase(Locale.ROOT))) {
                 final String message = String.format("Procedure name %s doesn't contain resolved pattern %s", procedureName, resolvedPattern);
                 throw new DmsException(message);
@@ -115,10 +118,10 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         if (Strings.isBlank(useCase.getIncomingNamePattern())) {
             // use resolved ContentObject name (filename) if no pattern for Incoming name is defined
             // resolved in this case means the UseCase#filenameOverwritePattern is applied first
-            incomingName = contentObjectName;
+            incomingName = contentObjectNameWithoutExtension;
         } else {
             // else apply pattern to original filename
-            incomingName = this.patternHelper.applyPattern(useCase.getIncomingNamePattern(), file.getFileName(), metadataJson);
+            incomingName = this.patternHelper.applyPattern(useCase.getIncomingNamePattern(), filenameWithoutExtension, metadataJson);
         }
         // resolve subject for Incoming;
         final String incomingSubject;

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -55,20 +55,20 @@ public class ProcessFileUseCase implements ProcessFileInPort {
                     metadataJson = dmsMetadataHelper.parseMetadataFile(metadataFileStream);
                 }
             }
-            // resolve target ressource type
-            final UseCase.Type targetRessource;
+            // resolve target resource type
+            final UseCase.Type targetResource;
             if (useCase.getType() == UseCase.Type.METADATA_FILE) {
-                targetRessource = this.resolveTypeFromMetadataFile(metadataJson);
+                targetResource = this.resolveTypeFromMetadataFile(metadataJson);
             } else {
-                targetRessource = useCase.getType();
+                targetResource = useCase.getType();
             }
             // get target coo
-            final DmsTarget dmsTarget = this.resolveTargetCoo(targetRessource, metadataJson, useCase, file);
+            final DmsTarget dmsTarget = this.resolveTargetCoo(targetResource, metadataJson, useCase, file);
             log.debug("Resolved dms target: {}", dmsTarget);
             // get ContentObject name
             final String contentObjectName = this.patternHelper.applyPattern(useCase.getFilenameOverwritePattern(), file.getFileName(), metadataJson);
             // transfer to dms
-            switch (targetRessource) {
+            switch (targetResource) {
             // to dms inbox
             case INBOX -> dmsOutPort.createContentObjectInInbox(dmsTarget, contentObjectName, fileStream);
             // create dms incoming
@@ -134,16 +134,16 @@ public class ProcessFileUseCase implements ProcessFileInPort {
      * Resolve target coo for useCase.
      * {@link UseCase.Type}
      *
-     * @param ressourceType Target type the coo is resolved for.
+     * @param resourceType Target type the coo is resolved for.
      * @param metadataJson Parsed JsonNode of metadata file.
      * @param useCase The use case.
      * @param file The file to resolve the coo for.
      * @return The resolved coo.
      */
-    protected DmsTarget resolveTargetCoo(final UseCase.Type ressourceType, final JsonNode metadataJson, final UseCase useCase, final File file)
+    protected DmsTarget resolveTargetCoo(final UseCase.Type resourceType, final JsonNode metadataJson, final UseCase useCase, final File file)
             throws MetadataException {
         return switch (useCase.getCooSource()) {
-        case METADATA_FILE -> this.resolveMetadataTargetCoo(ressourceType, metadataJson, useCase);
+        case METADATA_FILE -> this.resolveMetadataTargetCoo(resourceType, metadataJson, useCase);
         case FILENAME -> {
             if (Strings.isBlank(useCase.getFilenameCooPattern())) {
                 throw new IllegalArgumentException("Filename coo pattern is required");
@@ -172,14 +172,14 @@ public class ProcessFileUseCase implements ProcessFileInPort {
      * @param useCase UseCase of the file.
      * @return Resolved DmsTarget.
      */
-    protected DmsTarget resolveMetadataTargetCoo(final UseCase.Type ressourceType, final JsonNode metadataJson, final UseCase useCase)
+    protected DmsTarget resolveMetadataTargetCoo(final UseCase.Type resourceType, final JsonNode metadataJson, final UseCase useCase)
             throws MetadataException {
         // validate metadata json provided
         if (metadataJson == null) {
             throw new MetadataException("Metadata JSON is required");
         }
         // extract coo and username from metadata
-        final DmsTarget metadataTarget = switch (ressourceType) {
+        final DmsTarget metadataTarget = switch (resourceType) {
         case INBOX -> dmsMetadataHelper.resolveInboxDmsTarget(metadataJson);
         case INCOMING_OBJECT -> dmsMetadataHelper.resolveIncomingDmsTarget(metadataJson);
         case METADATA_FILE -> throw new IllegalStateException("Target type metadata needs to be resolved to other types");
@@ -189,7 +189,7 @@ public class ProcessFileUseCase implements ProcessFileInPort {
     }
 
     /**
-     * Resolve dms target ressource type from metadata file.
+     * Resolve dms target resource type from metadata file.
      *
      * @param metadataJson Parsed metadata json node.
      * @return The resolved type.

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -32,6 +32,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class ProcessFileUseCase implements ProcessFileInPort {
+    protected static final String METADATA_TARGET_TYPE_INBOX = "inbox";
+    protected static final String METADATA_TARGET_TYPE_INCOMING = "incoming";
+
     private final SwimDmsProperties swimDmsProperties;
     private final FileSystemOutPort fileSystemOutPort;
     private final DmsOutPort dmsOutPort;
@@ -205,8 +208,8 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         final String metadataDmsTarget = indexFields.get(swimDmsProperties.getMetadataDmsTargetKey());
         // resolve type from value
         return switch (metadataDmsTarget) {
-        case "inbox" -> UseCase.Type.INBOX;
-        case "incoming" -> UseCase.Type.INCOMING_OBJECT;
+        case METADATA_TARGET_TYPE_INBOX -> UseCase.Type.INBOX;
+        case METADATA_TARGET_TYPE_INCOMING -> UseCase.Type.INCOMING_OBJECT;
         case null, default ->
                 throw new MetadataException(String.format("DMS target type via metadata file: Unexpected %s value: %s", swimDmsProperties.getMetadataDmsTargetKey(), metadataDmsTarget));
         };

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -198,7 +198,7 @@ public class ProcessFileUseCase implements ProcessFileInPort {
     protected UseCase.Type resolveTypeFromMetadataFile(final JsonNode metadataJson) throws MetadataException {
         // validate metadata json provided
         if (metadataJson == null) {
-            throw new MetadataException("Metadata JSON is required");
+            throw new MetadataException("DMS target type via metadata file: Metadata JSON is required");
         }
         // load value from metadata file
         final Map<String, String> indexFields = this.dmsMetadataHelper.getIndexFields(metadataJson);
@@ -207,7 +207,8 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         return switch (metadataDmsTarget) {
         case "inbox" -> UseCase.Type.INBOX;
         case "incoming" -> UseCase.Type.INCOMING_OBJECT;
-        default -> throw new MetadataException(String.format("Unexpected %s value: %s", swimDmsProperties.getMetadataDmsTargetKey(), metadataDmsTarget));
+        case null, default ->
+                throw new MetadataException(String.format("DMS target type via metadata file: Unexpected %s value: %s", swimDmsProperties.getMetadataDmsTargetKey(), metadataDmsTarget));
         };
     }
 }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/DmsMeter.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/DmsMeter.java
@@ -17,7 +17,7 @@ public class DmsMeter {
      * Increment counter metric of successfully processed files.
      *
      * @param useCase The use case of the file.
-     * @param type The type of DMS ressource created.
+     * @param type The type of DMS resource created.
      */
     public void incrementProcessed(final String useCase, final String type) {
         final String key = useCase + "_" + type;

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
@@ -50,6 +50,16 @@ public class SwimDmsProperties {
     @NotBlank
     private String metadataIncomingUserKey;
     /**
+     * Var name in metadata file to get target incoming joboe from.
+     */
+    @NotBlank
+    private String metadataIncomingJoboeKey;
+    /**
+     * Var name in metadata file to get target incoming jobposition from.
+     */
+    @NotBlank
+    private String metadataIncomingJobpositionKey;
+    /**
      * Var name in metadata file to get dms target resource type from.
      */
     @NotBlank

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
@@ -39,6 +39,21 @@ public class SwimDmsProperties {
      */
     @NotBlank
     private String metadataGroupInboxUserKey;
+    /**
+     * Var name in metadata file to get target incoming coo from.
+     */
+    @NotBlank
+    private String metadataIncomingCooKey;
+    /**
+     * Var name in metadata file to get target incoming owner from.
+     */
+    @NotBlank
+    private String metadataIncomingUserKey;
+    /**
+     * Var name in metadata file to get dms target ressource type from.
+     */
+    @NotBlank
+    private String metadataDmsTargetKey;
 
     /**
      * Resolve use case via name.

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/configuration/SwimDmsProperties.java
@@ -50,7 +50,7 @@ public class SwimDmsProperties {
     @NotBlank
     private String metadataIncomingUserKey;
     /**
-     * Var name in metadata file to get dms target ressource type from.
+     * Var name in metadata file to get dms target resource type from.
      */
     @NotBlank
     private String metadataDmsTargetKey;

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
@@ -1,11 +1,11 @@
 package de.muenchen.oss.swim.dms.domain.helper;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.swim.dms.configuration.SwimDmsProperties;
 import de.muenchen.oss.swim.dms.domain.model.DmsTarget;
 import de.muenchen.oss.swim.libs.handlercore.domain.exception.MetadataException;
 import de.muenchen.oss.swim.libs.handlercore.domain.helper.MetadataHelper;
+import de.muenchen.oss.swim.libs.handlercore.domain.model.Metadata;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import org.apache.logging.log4j.util.Strings;
@@ -24,12 +24,12 @@ public class DmsMetadataHelper extends MetadataHelper {
     /**
      * Extract inbox dms target from metadata file.
      *
-     * @param rootNode Parsed JsonNode of metadata file.
+     * @param metadata Parsed metadata file.
      * @return The dms target.
      * @throws MetadataException If required values are missing.
      */
-    public DmsTarget resolveInboxDmsTarget(@NotNull final JsonNode rootNode) throws MetadataException {
-        final Map<String, String> indexFields = this.getIndexFields(rootNode);
+    public DmsTarget resolveInboxDmsTarget(@NotNull final Metadata metadata) throws MetadataException {
+        final Map<String, String> indexFields = metadata.indexFields();
         final String userInboxCoo = indexFields.get(swimDmsProperties.getMetadataUserInboxCooKey());
         final String userInboxOwner = indexFields.get(swimDmsProperties.getMetadataUserInboxUserKey());
         final String groupInboxCoo = indexFields.get(swimDmsProperties.getMetadataGroupInboxCooKey());
@@ -42,12 +42,12 @@ public class DmsMetadataHelper extends MetadataHelper {
      * Extract incoming or ou work queue dms target from metadata file.
      * For incoming {@link DmsTarget#coo()} is set and for ou work queue empty.
      *
-     * @param rootNode Parsed JsonNode of metadata file.
+     * @param metadata Parsed metadata file.
      * @return The incoming or ou work queue target.
      * @throws MetadataException If required values are missing.
      */
-    public DmsTarget resolveIncomingDmsTarget(@NotNull final JsonNode rootNode) throws MetadataException {
-        final Map<String, String> indexFields = this.getIndexFields(rootNode);
+    public DmsTarget resolveIncomingDmsTarget(@NotNull final Metadata metadata) throws MetadataException {
+        final Map<String, String> indexFields = metadata.indexFields();
         final String incomingCoo = indexFields.get(swimDmsProperties.getMetadataIncomingCooKey());
         final String incomingOwner = indexFields.get(swimDmsProperties.getMetadataIncomingUserKey());
         final String incomingJoboe = indexFields.get(swimDmsProperties.getMetadataIncomingJoboeKey());

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
@@ -40,6 +40,7 @@ public class DmsMetadataHelper extends MetadataHelper {
 
     /**
      * Extract incoming or ou work queue dms target from metadata file.
+     * For incoming {@link DmsTarget#coo()} is set and for ou work queue empty.
      *
      * @param rootNode Parsed JsonNode of metadata file.
      * @return The incoming or ou work queue target.
@@ -49,10 +50,12 @@ public class DmsMetadataHelper extends MetadataHelper {
         final Map<String, String> indexFields = this.getIndexFields(rootNode);
         final String incomingCoo = indexFields.get(swimDmsProperties.getMetadataIncomingCooKey());
         final String incomingOwner = indexFields.get(swimDmsProperties.getMetadataIncomingUserKey());
+        final String incomingJoboe = indexFields.get(swimDmsProperties.getMetadataIncomingJoboeKey());
+        final String incomingJobposition = indexFields.get(swimDmsProperties.getMetadataIncomingJobpositionKey());
         if (Strings.isBlank(incomingOwner)) {
             throw new MetadataException("Error while resolving incoming target from metadata: username is required");
         }
-        return new DmsTarget(Strings.isNotBlank(incomingCoo) ? incomingCoo : null, incomingOwner, null, null);
+        return new DmsTarget(Strings.isNotBlank(incomingCoo) ? incomingCoo : null, incomingOwner, incomingJoboe, incomingJobposition);
     }
 
     /**

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
@@ -49,7 +49,10 @@ public class DmsMetadataHelper extends MetadataHelper {
         final Map<String, String> indexFields = this.getIndexFields(rootNode);
         final String incomingCoo = indexFields.get(swimDmsProperties.getMetadataIncomingCooKey());
         final String incomingOwner = indexFields.get(swimDmsProperties.getMetadataIncomingUserKey());
-        return new DmsTarget(incomingCoo, incomingOwner, null, null);
+        if (Strings.isBlank(incomingOwner)) {
+            throw new MetadataException("Error while resolving incoming target from metadata: username is required");
+        }
+        return new DmsTarget(Strings.isNotBlank(incomingCoo) ? incomingCoo : null, incomingOwner, null, null);
     }
 
     /**

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelper.java
@@ -39,6 +39,20 @@ public class DmsMetadataHelper extends MetadataHelper {
     }
 
     /**
+     * Extract incoming or ou work queue dms target from metadata file.
+     *
+     * @param rootNode Parsed JsonNode of metadata file.
+     * @return The incoming or ou work queue target.
+     * @throws MetadataException If required values are missing.
+     */
+    public DmsTarget resolveIncomingDmsTarget(@NotNull final JsonNode rootNode) throws MetadataException {
+        final Map<String, String> indexFields = this.getIndexFields(rootNode);
+        final String incomingCoo = indexFields.get(swimDmsProperties.getMetadataIncomingCooKey());
+        final String incomingOwner = indexFields.get(swimDmsProperties.getMetadataIncomingUserKey());
+        return new DmsTarget(incomingCoo, incomingOwner, null, null);
+    }
+
+    /**
      * Resolve correct DmsTarget from user and group inbox values.
      *
      * @param userInboxCoo The value for the user inbox coo.

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
@@ -90,7 +90,11 @@ public class UseCase {
          * Either inside given Procedure {@link DmsTarget#coo()} or OU work queue of
          * {@link DmsTarget#userName()}.
          */
-        INCOMING_OBJECT
+        INCOMING_OBJECT,
+        /**
+         * Resolve target ressource type from metadata file.
+         */
+        METADATA_FILE
     }
 
     public enum CooSource {

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
@@ -92,7 +92,7 @@ public class UseCase {
          */
         INCOMING_OBJECT,
         /**
-         * Resolve target ressource type from metadata file.
+         * Resolve target resource type from metadata file.
          */
         METADATA_FILE
     }

--- a/dms-service/src/main/resources/application-local.yml
+++ b/dms-service/src/main/resources/application-local.yml
@@ -32,3 +32,6 @@ swim:
   metadata-user-inbox-user-key: "PPK_Username"
   metadata-group-inbox-coo-key: "GPK_COO"
   metadata-group-inbox-user-key: "GPK_Username"
+  metadata-dms-target-key: "SWIM_DMS_Target"
+  metadata-incoming-coo-key: "VG_COO"
+  metadata-incoming-user-key: "VG_Username"

--- a/dms-service/src/main/resources/application-local.yml
+++ b/dms-service/src/main/resources/application-local.yml
@@ -28,6 +28,3 @@ swim:
     - name: test-meta
       type: inbox
       coo-source: metadata_file
-  metadata-dms-target-key: "SWIM_DMS_Target"
-  metadata-incoming-coo-key: "VG_COO"
-  metadata-incoming-user-key: "VG_Username"

--- a/dms-service/src/main/resources/application.yml
+++ b/dms-service/src/main/resources/application.yml
@@ -84,8 +84,13 @@ info:
     spring-cloud.version: @spring-cloud-dependencies.version@
 
 swim:
+  metadata-dms-target-key: "SWIM_DMS_Target"
+  metadata-subject-prefix: "FdE_"
   metadata-user-inbox-coo-key: "PPK_COO"
   metadata-user-inbox-user-key: "PPK_Username"
   metadata-group-inbox-coo-key: "GPK_COO"
   metadata-group-inbox-user-key: "GPK_Username"
-  metadata-subject-prefix: "FdE_"
+  metadata-incoming-coo-key: "VG_COO"
+  metadata-incoming-user-key: "VG_Username"
+  metadata-incoming-joboe-key: "VG_Joboe"
+  metadata-incoming-jobposition-key: "VG_Jobposition"

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/TestConstants.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/TestConstants.java
@@ -14,5 +14,7 @@ public final class TestConstants {
 
     public final static DmsTarget METADATA_DMS_TARGET_USER = new DmsTarget("userMetadataCoo", "metadata.user", null, null);
     public final static DmsTarget METADATA_DMS_TARGET_GROUP = new DmsTarget("groupMetadataCoo", "metadata.group", null, null);
+    public final static DmsTarget METADATA_DMS_TARGET_INCOMING = new DmsTarget("incomingMetadataCoo", "metadata.user", null, null);
+    public final static DmsTarget METADATA_DMS_TARGET_OU_WORK_QUEUE = new DmsTarget(null, "metadata.user", null, null);
 
 }

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -109,7 +109,7 @@ class ProcessFileUseCaseTest {
         verify(processFileUseCase, times(1)).resolveTypeFromMetadataFile(any());
         verify(processFileUseCase, times(1)).resolveTargetCoo(eq(UseCase.Type.INCOMING_OBJECT), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(1)).resolveIncomingDmsTarget(any());
-        verify(dmsOutPort, times(1)).createIncoming(eq(METADATA_DMS_TARGET_INCOMING), eq(FILE_NAME), eq(FILE_NAME), eq(null));
+        verify(dmsOutPort, times(1)).createIncoming(eq(METADATA_DMS_TARGET_INCOMING), eq(FILE_NAME), eq(FILE_NAME), eq(FILE_NAME), eq(null));
     }
 
     @Test
@@ -195,7 +195,8 @@ class ProcessFileUseCaseTest {
         verify(dmsOutPort, times(1)).createContentObject(eq(dmsTarget), eq(FILE_NAME), eq(null));
     }
 
-    private void testDefaults(final String useCaseName, final UseCase.Type targetType, final DmsTarget dmsTarget, final String incomingName, final String incomingSubject,
+    private void testDefaults(final String useCaseName, final UseCase.Type targetType, final DmsTarget dmsTarget, final String incomingName,
+            final String incomingSubject,
             final String contentObjectName)
             throws UnknownUseCaseException, MetadataException {
         final UseCase useCase = swimDmsProperties.findUseCase(useCaseName);

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -90,7 +90,7 @@ class ProcessFileUseCaseTest {
         processFileUseCase.processFile(buildFileEvent(useCaseName, METADATA_PRESIGNED_URL), FILE);
         // test
         verify(swimDmsProperties, times(2)).findUseCase(eq(useCaseName));
-        verify(processFileUseCase, times(1)).resolveTargetCoo(any(), eq(useCase), eq(FILE));
+        verify(processFileUseCase, times(1)).resolveTargetCoo(eq(UseCase.Type.INBOX), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(1)).resolveInboxDmsTarget(any());
         verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(METADATA_DMS_TARGET_USER), eq(FILE_NAME), eq(null));
         verify(dmsMeter, times(1)).incrementProcessed(eq(useCaseName), eq("INBOX"));
@@ -103,7 +103,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, STATIC_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, overwrittenContentObjectName);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, STATIC_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, overwrittenContentObjectName);
         verify(dmsOutPort, times(0)).getProcedureName(any());
         verify(dmsOutPort, times(0)).getIncomingCooByName(any(), any());
     }
@@ -114,7 +114,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
     }
 
     @Test
@@ -123,7 +123,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
         // call catch all
         final String fileName = "asd.pdf";
         final String filePath = "test/asd.pdf";
@@ -144,7 +144,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME);
         verify(dmsOutPort, times(1)).getProcedureName(eq(FILENAME_DMS_TARGET));
         // setup failure
         when(dmsOutPort.getProcedureName(eq(FILENAME_DMS_TARGET))).thenReturn("asd");
@@ -161,7 +161,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, FILENAME_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, FILE_NAME);
         verify(dmsOutPort, times(1)).getIncomingCooByName(eq(FILENAME_DMS_TARGET), eq(OVERWRITTEN_INCOMING_NAME));
         // setup reuse
         when(dmsOutPort.getIncomingCooByName(eq(FILENAME_DMS_TARGET), eq(OVERWRITTEN_INCOMING_NAME))).thenReturn(Optional.of("COO.321.321.321"));
@@ -175,12 +175,12 @@ class ProcessFileUseCaseTest {
         verify(dmsOutPort, times(1)).createContentObject(eq(dmsTarget), eq(FILE_NAME), eq(null));
     }
 
-    private void testDefaults(final String useCaseName, final DmsTarget dmsTarget, final String fileName,
+    private void testDefaults(final String useCaseName, final UseCase.Type targetType, final DmsTarget dmsTarget, final String fileName,
             final String contentObjectName)
             throws UnknownUseCaseException, MetadataException {
         final UseCase useCase = swimDmsProperties.findUseCase(useCaseName);
         verify(swimDmsProperties, times(2)).findUseCase(eq(useCaseName));
-        verify(processFileUseCase, times(1)).resolveTargetCoo(isNull(), eq(useCase), eq(FILE));
+        verify(processFileUseCase, times(1)).resolveTargetCoo(eq(targetType), isNull(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(0)).resolveInboxDmsTarget(any());
         verify(dmsOutPort, times(0)).createContentObjectInInbox(any(), any(), any());
         verify(dmsOutPort, times(1)).createIncoming(eq(dmsTarget), eq(fileName), eq(contentObjectName), eq(null));

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -109,7 +109,8 @@ class ProcessFileUseCaseTest {
         verify(processFileUseCase, times(1)).resolveTypeFromMetadataFile(any());
         verify(processFileUseCase, times(1)).resolveTargetCoo(eq(UseCase.Type.INCOMING_OBJECT), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(1)).resolveIncomingDmsTarget(any());
-        verify(dmsOutPort, times(1)).createIncoming(eq(METADATA_DMS_TARGET_INCOMING), eq(FILE_NAME), eq(FILE_NAME), eq(FILE_NAME), eq(null));
+        verify(dmsOutPort, times(1)).createIncoming(eq(METADATA_DMS_TARGET_INCOMING), eq(FILE_NAME_WITHOUT_EXTENSION), eq(FILE_NAME_WITHOUT_EXTENSION),
+                eq(FILE_NAME), eq(null));
     }
 
     @Test
@@ -134,7 +135,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
     }
 
     @Test
@@ -143,9 +144,10 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
         // call catch all
-        final String fileName = "asd.pdf";
+        final String fileNameWithoutExtension = "asd";
+        final String fileName = String.format("%s.pdf", fileNameWithoutExtension);
         final String filePath = "test/asd.pdf";
         final File file = new File(BUCKET, filePath);
         final String presignedUrl = String.format("http://localhost:9001/%s/%s", BUCKET, filePath);
@@ -153,7 +155,7 @@ class ProcessFileUseCaseTest {
         processFileUseCase.processFile(new FileEvent(useCaseName, presignedUrl, null), file);
         final DmsTarget dmsTarget = new DmsTarget("COO.321.321.321", useCase.getUsername(), useCase.getJoboe(), useCase.getJobposition());
         // test catche all
-        verify(dmsOutPort, times(1)).createIncoming(eq(dmsTarget), eq(fileName), eq(fileName), eq(fileName), eq(null));
+        verify(dmsOutPort, times(1)).createIncoming(eq(dmsTarget), eq(fileNameWithoutExtension), eq(fileNameWithoutExtension), eq(fileName), eq(null));
     }
 
     @Test
@@ -164,7 +166,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME, FILE_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCase.Type.INCOMING_OBJECT, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
         verify(dmsOutPort, times(1)).getProcedureName(eq(FILENAME_DMS_TARGET));
         // setup failure
         when(dmsOutPort.getProcedureName(eq(FILENAME_DMS_TARGET))).thenReturn("asd");

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelperTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelperTest.java
@@ -1,6 +1,8 @@
 package de.muenchen.oss.swim.dms.domain.helper;
 
 import static de.muenchen.oss.swim.dms.TestConstants.METADATA_DMS_TARGET_GROUP;
+import static de.muenchen.oss.swim.dms.TestConstants.METADATA_DMS_TARGET_INCOMING;
+import static de.muenchen.oss.swim.dms.TestConstants.METADATA_DMS_TARGET_OU_WORK_QUEUE;
 import static de.muenchen.oss.swim.dms.TestConstants.METADATA_DMS_TARGET_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,5 +51,23 @@ class DmsMetadataHelperTest {
         final JsonNode metadataInvalidEmpty = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-empty.json"));
         assertThrows(MetadataException.class,
                 () -> dmsMetadataHelper.resolveInboxDmsTarget(metadataInvalidEmpty));
+    }
+
+    @Test
+    void testResolveIncomingDmsTarget() throws MetadataException {
+        // test inbox
+        final JsonNode metadataNode = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-incoming.json"));
+        final DmsTarget dmsTarget = dmsMetadataHelper.resolveIncomingDmsTarget(metadataNode);
+        assertEquals(METADATA_DMS_TARGET_INCOMING, dmsTarget);
+        // test ou work queue
+        final JsonNode metadataNodeWorkQueue = dmsMetadataHelper
+                .parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-ou-work-queue.json"));
+        final DmsTarget dmsTargetWorkQueue = dmsMetadataHelper.resolveIncomingDmsTarget(metadataNodeWorkQueue);
+        assertEquals(METADATA_DMS_TARGET_OU_WORK_QUEUE, dmsTargetWorkQueue);
+        // empty
+        final JsonNode metadataNodeEmpty = dmsMetadataHelper
+                .parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-empty.json"));
+        assertThrows(MetadataException.class, () -> dmsMetadataHelper.resolveIncomingDmsTarget(metadataNodeEmpty));
+
     }
 }

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelperTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/DmsMetadataHelperTest.java
@@ -7,12 +7,12 @@ import static de.muenchen.oss.swim.dms.TestConstants.METADATA_DMS_TARGET_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.swim.dms.TestConstants;
 import de.muenchen.oss.swim.dms.configuration.SwimDmsProperties;
 import de.muenchen.oss.swim.dms.domain.model.DmsTarget;
 import de.muenchen.oss.swim.libs.handlercore.domain.exception.MetadataException;
+import de.muenchen.oss.swim.libs.handlercore.domain.model.Metadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,23 +32,23 @@ class DmsMetadataHelperTest {
     @Test
     void testResolveInboxDmsTarget() throws MetadataException {
         // test user
-        final JsonNode metadataUserNode = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-user.json"));
-        final DmsTarget dmsTargetUser = dmsMetadataHelper.resolveInboxDmsTarget(metadataUserNode);
+        final Metadata metadataUser = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-user.json"));
+        final DmsTarget dmsTargetUser = dmsMetadataHelper.resolveInboxDmsTarget(metadataUser);
         assertEquals(METADATA_DMS_TARGET_USER, dmsTargetUser);
         // test group
-        final JsonNode metadataGroupNode = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-group.json"));
-        final DmsTarget dmsTargetGroup = dmsMetadataHelper.resolveInboxDmsTarget(metadataGroupNode);
+        final Metadata metadataGroup = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-group.json"));
+        final DmsTarget dmsTargetGroup = dmsMetadataHelper.resolveInboxDmsTarget(metadataGroup);
         assertEquals(METADATA_DMS_TARGET_GROUP, dmsTargetGroup);
         // test invalid both
-        final JsonNode metadataInvalidBoth = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-both.json"));
+        final Metadata metadataInvalidBoth = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-both.json"));
         assertThrows(MetadataException.class,
                 () -> dmsMetadataHelper.resolveInboxDmsTarget(metadataInvalidBoth));
         // test invalid none
-        final JsonNode metadataInvalidNone = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-none.json"));
+        final Metadata metadataInvalidNone = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-none.json"));
         assertThrows(MetadataException.class,
                 () -> dmsMetadataHelper.resolveInboxDmsTarget(metadataInvalidNone));
         // test invalid empty
-        final JsonNode metadataInvalidEmpty = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-empty.json"));
+        final Metadata metadataInvalidEmpty = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-empty.json"));
         assertThrows(MetadataException.class,
                 () -> dmsMetadataHelper.resolveInboxDmsTarget(metadataInvalidEmpty));
     }
@@ -56,16 +56,16 @@ class DmsMetadataHelperTest {
     @Test
     void testResolveIncomingDmsTarget() throws MetadataException {
         // test inbox
-        final JsonNode metadataNode = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-incoming.json"));
-        final DmsTarget dmsTarget = dmsMetadataHelper.resolveIncomingDmsTarget(metadataNode);
+        final Metadata metadata = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-incoming.json"));
+        final DmsTarget dmsTarget = dmsMetadataHelper.resolveIncomingDmsTarget(metadata);
         assertEquals(METADATA_DMS_TARGET_INCOMING, dmsTarget);
         // test ou work queue
-        final JsonNode metadataNodeWorkQueue = dmsMetadataHelper
+        final Metadata metadataNodeWorkQueue = dmsMetadataHelper
                 .parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-ou-work-queue.json"));
         final DmsTarget dmsTargetWorkQueue = dmsMetadataHelper.resolveIncomingDmsTarget(metadataNodeWorkQueue);
         assertEquals(METADATA_DMS_TARGET_OU_WORK_QUEUE, dmsTargetWorkQueue);
         // empty
-        final JsonNode metadataNodeEmpty = dmsMetadataHelper
+        final Metadata metadataNodeEmpty = dmsMetadataHelper
                 .parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-invalid-empty.json"));
         assertThrows(MetadataException.class, () -> dmsMetadataHelper.resolveIncomingDmsTarget(metadataNodeEmpty));
 

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/PatternHelperTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/domain/helper/PatternHelperTest.java
@@ -3,11 +3,11 @@ package de.muenchen.oss.swim.dms.domain.helper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.muenchen.oss.swim.dms.TestConstants;
 import de.muenchen.oss.swim.dms.configuration.SwimDmsProperties;
 import de.muenchen.oss.swim.libs.handlercore.domain.exception.MetadataException;
+import de.muenchen.oss.swim.libs.handlercore.domain.model.Metadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,8 +36,8 @@ class PatternHelperTest {
         final String resultRegex = patternHelper.applyPattern("s/(.+)-COO[\\d\\.]+-(.*)/${1}-${2}/", TEST_FILENAME, null);
         assertEquals("Test123-ExampleTest.pdf", resultRegex);
         // named regex and metadata pattern
-        final JsonNode metadataNode = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-user.json"));
-        final String result = patternHelper.applyPattern("s/(?<p1>.+)-COO[\\d\\.]+-(?<p2>.*)/${p1}_${if.PPK_Username}_${p2}/m", TEST_FILENAME, metadataNode);
+        final Metadata metadata = dmsMetadataHelper.parseMetadataFile(getClass().getResourceAsStream("/files/example-metadata-user.json"));
+        final String result = patternHelper.applyPattern("s/(?<p1>.+)-COO[\\d\\.]+-(?<p2>.*)/${p1}_${if.PPK_Username}_${p2}/m", TEST_FILENAME, metadata);
         assertEquals("Test123_metadata.user_ExampleTest.pdf", result);
         // missing metadata
         assertThrows(IllegalArgumentException.class, () -> patternHelper.applyPattern("s/(.+)-COO[\\d\\.]+-(.*)/${1}-${2}/m", TEST_FILENAME, null));

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -3,6 +3,9 @@ swim:
     - name: metadata-inbox
       type: inbox
       coo-source: metadata_file
+    - name: metadata-metadata
+      type: metadata_file
+      coo-source: metadata_file
     - name: static-incoming
       type: incoming_object
       coo-source: static

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -49,6 +49,3 @@ swim:
       username: staticUsername
       joboe: staticJobOe
       jobposition: staticJobPosition
-  metadata-dms-target-key: "SWIM_DMS_Target"
-  metadata-incoming-coo-key: "VG_COO"
-  metadata-incoming-user-key: "VG_Username"

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -49,3 +49,6 @@ swim:
   metadata-user-inbox-user-key: "PPK_Username"
   metadata-group-inbox-coo-key: "GPK_COO"
   metadata-group-inbox-user-key: "GPK_Username"
+  metadata-dms-target-key: "SWIM_DMS_Target"
+  metadata-incoming-coo-key: "VG_COO"
+  metadata-incoming-user-key: "VG_Username"

--- a/dms-service/src/test/resources/files/example-metadata-incoming.json
+++ b/dms-service/src/test/resources/files/example-metadata-incoming.json
@@ -1,0 +1,14 @@
+{
+  "Document": {
+    "IndexFields": [
+      {
+        "Name": "VG_COO",
+        "Value": "incomingMetadataCoo"
+      },
+      {
+        "Name": "VG_Username",
+        "Value": "metadata.user"
+      }
+    ]
+  }
+}

--- a/dms-service/src/test/resources/files/example-metadata-ou-work-queue.json
+++ b/dms-service/src/test/resources/files/example-metadata-ou-work-queue.json
@@ -1,0 +1,14 @@
+{
+  "Document": {
+    "IndexFields": [
+      {
+        "Name": "VG_COO",
+        "Value": ""
+      },
+      {
+        "Name": "VG_Username",
+        "Value": "metadata.user"
+      }
+    ]
+  }
+}

--- a/dms-service/src/test/resources/files/example-metadata-target-type-incoming.json
+++ b/dms-service/src/test/resources/files/example-metadata-target-type-incoming.json
@@ -1,0 +1,18 @@
+{
+  "Document": {
+    "IndexFields": [
+      {
+        "Name": "SWIM_DMS_Target",
+        "Value": "incoming"
+      },
+      {
+        "Name": "VG_COO",
+        "Value": "incomingMetadataCoo"
+      },
+      {
+        "Name": "VG_Username",
+        "Value": "metadata.user"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Description**

Feature for resolving dms target ressource type (inbox/incoming) via field in metadata file.

**Reference**

Issues closes #98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced file processing with metadata-based resolution, ensuring accurate target type determination.
  - Expanded configuration options to support flexible metadata handling for incoming resources.
  - Introduced new JSON files for structured representation of document metadata.
  - New method for resolving incoming DMS targets based on metadata.

- **Documentation**
  - Updated guides and examples to reflect new metadata configuration keys and proper metadata file structures.

- **Tests**
  - Added test cases to validate metadata processing and improved error handling for incoming targets.
  - Updated existing tests to accommodate changes in metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->