### PR TITLE
feat/dms-inbox-content-object-subject

### DIFF
--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -25,7 +25,7 @@
 
         <!-- Core Frameworks -->
         <spring-cloud-dependencies.version>2024.0.0</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
-        <refarch-dms-integration-fabasoft-rest-api.version>1.4.0</refarch-dms-integration-fabasoft-rest-api.version>
+        <refarch-dms-integration-fabasoft-rest-api.version>1.4.1</refarch-dms-integration-fabasoft-rest-api.version>
         <swim-handler-core.version>0.2.0</swim-handler-core.version>
 
         <!-- Logging -->

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/adapter/out/dms/DmsAdapter.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/adapter/out/dms/DmsAdapter.java
@@ -71,7 +71,7 @@ public class DmsAdapter implements DmsOutPort {
                     null,
                     null,
                     List.of(file)).block();
-            if (response != null && response.getListcontents() != null && response.getListcontents().size() != 1) {
+            if (response != null && response.getListcontents() != null && response.getListcontents().size() == 1) {
                 final String coo = response.getListcontents().getFirst().getObjaddress();
                 log.info("Created new ContentObject {} in Inbox {}", coo, dmsTarget);
                 return coo;

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
@@ -18,6 +18,7 @@ public interface DmsOutPort {
      *
      * @param dmsTarget The target Inbox.
      * @param contentObjectName The name of the new ContentObject.
+     * @param contentObjectSubject The subject of the new ContentObject.
      * @param inputStream The content of the new ContentObject.
      */
     void createContentObjectInInbox(@NotNull @Valid DmsTarget dmsTarget, @NotBlank String contentObjectName, String contentObjectSubject,

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
@@ -19,8 +19,10 @@ public interface DmsOutPort {
      * @param dmsTarget The target Inbox.
      * @param contentObjectName The name of the new ContentObject.
      * @param inputStream The content of the new ContentObject.
+     * @return The coo of the new ContentObject.
      */
-    void createContentObjectInInbox(@NotNull @Valid DmsTarget dmsTarget, @NotBlank String contentObjectName, @NotNull InputStream inputStream);
+    String createContentObjectInInbox(@NotNull @Valid DmsTarget dmsTarget, @NotBlank String contentObjectName, String contentObjectSubject,
+            @NotNull InputStream inputStream);
 
     /**
      * Create Incoming.

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/port/out/DmsOutPort.java
@@ -19,9 +19,8 @@ public interface DmsOutPort {
      * @param dmsTarget The target Inbox.
      * @param contentObjectName The name of the new ContentObject.
      * @param inputStream The content of the new ContentObject.
-     * @return The coo of the new ContentObject.
      */
-    String createContentObjectInInbox(@NotNull @Valid DmsTarget dmsTarget, @NotBlank String contentObjectName, String contentObjectSubject,
+    void createContentObjectInInbox(@NotNull @Valid DmsTarget dmsTarget, @NotBlank String contentObjectName, String contentObjectSubject,
             @NotNull InputStream inputStream);
 
     /**

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -72,14 +72,10 @@ public class ProcessFileUseCase implements ProcessFileInPort {
             // get ContentObject name and subject
             final String contentObjectName = this.patternHelper.applyPattern(useCase.getContentObject().getFilenameOverwritePattern(), file.getFileName(),
                     metadata);
-            final String contentObjectSubjectPattern = useCase.getContentObject().getSubjectPattern();
-            final String contentObjectSubject = Strings.isNotBlank(contentObjectSubjectPattern)
-                    ? this.patternHelper.applyPattern(contentObjectSubjectPattern, file.getFileName(), metadata)
-                    : null;
             // transfer to dms
             switch (targetResource) {
             // to dms inbox
-            case INBOX_CONTENT_OBJECT -> dmsOutPort.createContentObjectInInbox(dmsTarget, contentObjectName, contentObjectSubject, fileStream);
+            case INBOX_CONTENT_OBJECT -> this.processInboxContentObject(file, useCase, dmsTarget, contentObjectName, fileStream, metadata);
             // create dms incoming
             case PROCEDURE_INCOMING -> this.processIncoming(file, useCase, dmsTarget, contentObjectName, fileStream, metadata);
             case METADATA_FILE -> throw new IllegalStateException("Target type metadata needs to be resolved to other types");
@@ -148,6 +144,27 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         }
         // create Incoming
         dmsOutPort.createIncoming(dmsTarget, incomingName, incomingSubject, contentObjectName, fileStream);
+    }
+
+    /**
+     * Process {@link UseCaseType#INBOX_CONTENT_OBJECT} files.
+     *
+     * @param file The file to process.
+     * @param useCase The use case of the file.
+     * @param dmsTarget The resolved dms target.
+     * @param contentObjectName The resolved name of the new ContentObject.
+     * @param fileStream The content of the file.
+     * @param metadata Parsed metadata file.
+     */
+    protected void processInboxContentObject(final File file, final UseCase useCase, final DmsTarget dmsTarget, final String contentObjectName,
+            final InputStream fileStream, final Metadata metadata) {
+        // resolve ContentObject subject
+        final String contentObjectSubjectPattern = useCase.getContentObject().getSubjectPattern();
+        final String contentObjectSubject = Strings.isNotBlank(contentObjectSubjectPattern)
+                ? this.patternHelper.applyPattern(contentObjectSubjectPattern, file.getFileName(), metadata)
+                : null;
+        // create ContentObject
+        this.dmsOutPort.createContentObjectInInbox(dmsTarget, contentObjectName, contentObjectSubject, fileStream);
     }
 
     /**

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -69,13 +69,17 @@ public class ProcessFileUseCase implements ProcessFileInPort {
             // get target coo
             final DmsTarget dmsTarget = this.resolveTargetCoo(targetResource, metadata, useCase, file);
             log.debug("Resolved dms target: {}", dmsTarget);
-            // get ContentObject name
+            // get ContentObject name and subject
             final String contentObjectName = this.patternHelper.applyPattern(useCase.getContentObject().getFilenameOverwritePattern(), file.getFileName(),
                     metadata);
+            final String contentObjectSubjectPattern = useCase.getContentObject().getSubjectPattern();
+            final String contentObjectSubject = Strings.isNotBlank(contentObjectSubjectPattern)
+                    ? this.patternHelper.applyPattern(contentObjectSubjectPattern, file.getFileName(), metadata)
+                    : null;
             // transfer to dms
             switch (targetResource) {
             // to dms inbox
-            case INBOX_CONTENT_OBJECT -> dmsOutPort.createContentObjectInInbox(dmsTarget, contentObjectName, fileStream);
+            case INBOX_CONTENT_OBJECT -> dmsOutPort.createContentObjectInInbox(dmsTarget, contentObjectName, contentObjectSubject, fileStream);
             // create dms incoming
             case PROCEDURE_INCOMING -> this.processIncoming(file, useCase, dmsTarget, contentObjectName, fileStream, metadata);
             case METADATA_FILE -> throw new IllegalStateException("Target type metadata needs to be resolved to other types");

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCaseContentObject.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCaseContentObject.java
@@ -16,4 +16,10 @@ public class UseCaseContentObject {
      */
     @Pattern(regexp = PatternHelper.RAW_PATTERN)
     private String filenameOverwritePattern;
+    /**
+     * Regex pattern for setting subject in dms by providing regex pattern.
+     * Pattern is applied to S3 filename.
+     */
+    @Pattern(regexp = PatternHelper.RAW_PATTERN)
+    private String subjectPattern;
 }

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -100,6 +100,17 @@ class ProcessFileUseCaseTest {
     }
 
     @Test
+    void testProcessFile_StaticInbox() throws UnknownUseCaseException, PresignedUrlException, MetadataException {
+        final String useCaseName = "static-inbox";
+        // setup
+        when(fileSystemOutPort.getPresignedUrlFile(eq(METADATA_PRESIGNED_URL))).thenReturn(getClass().getResourceAsStream("/files/example-metadata-user.json"));
+        // call
+        processFileUseCase.processFile(buildFileEvent(useCaseName, METADATA_PRESIGNED_URL), FILE);
+        // test
+        verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(STATIC_DMS_TARGET), eq(FILE_NAME), eq("test"), eq(null));
+    }
+
+    @Test
     void testProcessFile_MetadataViaMetadata() throws UnknownUseCaseException, PresignedUrlException, MetadataException {
         final String useCaseName = "metadata-metadata";
         final UseCase useCase = swimDmsProperties.findUseCase(useCaseName);

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -76,7 +76,8 @@ class ProcessFileUseCaseTest {
     private final static String METADATA_PRESIGNED_URL = String.format("http://localhost:9001/%s/%s", BUCKET, METADAT_PATH);
     private final static DmsTarget STATIC_DMS_TARGET = new DmsTarget("staticCoo", "staticUsername", "staticJobOe", "staticJobPosition");
     private final static DmsTarget FILENAME_DMS_TARGET = new DmsTarget("COO.123.123.123", "staticUsername", "staticJobOe", "staticJobPosition");
-    public static final String OVERWRITTEN_INCOMING_NAME = "test";
+    public static final String PATTERN_VALUE_TEST = "test";
+    public static final String OVERWRITTEN_INCOMING_NAME = PATTERN_VALUE_TEST;
 
     @BeforeEach
     void setup() throws PresignedUrlException {
@@ -107,7 +108,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, METADATA_PRESIGNED_URL), FILE);
         // test
-        verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(STATIC_DMS_TARGET), eq(FILE_NAME), eq("test"), eq(null));
+        verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(STATIC_DMS_TARGET), eq(FILE_NAME), eq(PATTERN_VALUE_TEST), eq(null));
     }
 
     @Test
@@ -175,12 +176,12 @@ class ProcessFileUseCaseTest {
     @Test
     void testProcessFile_FilenameNameIncoming() throws UnknownUseCaseException, PresignedUrlException, MetadataException {
         final String useCaseName = "filename-name-incoming";
-        when(dmsOutPort.findObjectsByName(eq(DmsResourceType.PROCEDURE), eq("test"), any())).thenReturn(List.of("COO.123.123.123"));
+        when(dmsOutPort.findObjectsByName(eq(DmsResourceType.PROCEDURE), eq(PATTERN_VALUE_TEST), any())).thenReturn(List.of("COO.123.123.123"));
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
         testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
-        verify(dmsOutPort, times(1)).findObjectsByName(eq(DmsResourceType.PROCEDURE), eq("test"), any());
+        verify(dmsOutPort, times(1)).findObjectsByName(eq(DmsResourceType.PROCEDURE), eq(PATTERN_VALUE_TEST), any());
     }
 
     @Test

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -95,7 +95,7 @@ class ProcessFileUseCaseTest {
         verify(swimDmsProperties, times(2)).findUseCase(eq(useCaseName));
         verify(processFileUseCase, times(1)).resolveTargetCoo(eq(UseCaseType.INBOX_CONTENT_OBJECT), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(1)).resolveInboxDmsTarget(any());
-        verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(METADATA_DMS_TARGET_USER), eq(FILE_NAME), eq(null));
+        verify(dmsOutPort, times(1)).createContentObjectInInbox(eq(METADATA_DMS_TARGET_USER), eq(FILE_NAME), eq(null), eq(null));
         verify(dmsMeter, times(1)).incrementProcessed(eq(useCaseName), eq("INBOX_CONTENT_OBJECT"));
     }
 
@@ -219,7 +219,7 @@ class ProcessFileUseCaseTest {
         verify(swimDmsProperties, times(2)).findUseCase(eq(useCaseName));
         verify(processFileUseCase, times(1)).resolveTargetCoo(eq(targetType), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(0)).resolveInboxDmsTarget(any());
-        verify(dmsOutPort, times(0)).createContentObjectInInbox(any(), any(), any());
+        verify(dmsOutPort, times(0)).createContentObjectInInbox(any(), any(), any(), any());
         verify(dmsOutPort, times(1)).createIncoming(eq(dmsTarget), eq(incomingName), eq(incomingSubject), eq(contentObjectName), eq(null));
     }
 

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -4,6 +4,17 @@ swim:
       type: inbox_content_object
       coo-source:
         type: metadata_file
+    - name: static-inbox
+      type: inbox_content_object
+      coo-source:
+        type: static
+        target-coo: staticCoo
+      content-object:
+        subject-pattern: "s/^(.+)(?:-COO.[^-]+-).+$/\\${1}/"
+      context:
+        username: staticUsername
+        joboe: staticJobOe
+        jobposition: staticJobPosition
     - name: metadata-metadata
       type: metadata_file
       coo-source:


### PR DESCRIPTION
**Description**

Init dms Inbox ContentObject subject via pattern.

**Reference**

Issues closes #118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document creation in the inbox: you can now specify a subject when adding new content, improving the clarity of document references.
  - Added a new use case configuration for static content, enhancing functionality.
- **Chores**
  - Upgraded an integration component to its latest version for better overall system stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->