### PR TITLE
feat/dms-unify-pattern-input

### DIFF
--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/File.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/File.java
@@ -11,19 +11,9 @@ public record File(@NotBlank String bucket, @NotBlank String path, Long size) {
         return path.substring(path.lastIndexOf('/') + 1);
     }
 
-    /**
-     * Get filename without file extension.
-     *
-     * @return The filename without extension.
-     * @throws IllegalArgumentException If filename has no extension.
-     */
     public String getFileNameWithoutExtension() {
         final String fileName = this.getFileName();
-        final int lastPointIndex = fileName.lastIndexOf('.');
-        if (lastPointIndex == -1) {
-            throw new IllegalArgumentException("Filename has no extension");
-        }
-        return fileName.substring(0, lastPointIndex);
+        return fileName.substring(0, fileName.lastIndexOf('.'));
     }
 
     public String getParentPath() {

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/File.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/File.java
@@ -11,9 +11,19 @@ public record File(@NotBlank String bucket, @NotBlank String path, Long size) {
         return path.substring(path.lastIndexOf('/') + 1);
     }
 
+    /**
+     * Get filename without file extension.
+     *
+     * @return The filename without extension.
+     * @throws IllegalArgumentException If filename has no extension.
+     */
     public String getFileNameWithoutExtension() {
         final String fileName = this.getFileName();
-        return fileName.substring(0, fileName.lastIndexOf('.'));
+        final int lastPointIndex = fileName.lastIndexOf('.');
+        if (lastPointIndex == -1) {
+            throw new IllegalArgumentException("Filename has no extension");
+        }
+        return fileName.substring(0, lastPointIndex);
     }
 
     public String getParentPath() {

--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -76,6 +76,7 @@ swim:
         jobposition: # used to resolve user role under which the DMS action is executed, default role if not defined
       incoming:
         incoming-name-pattern: # overwrite Incoming name via Regex pattern
+        reuse-incoming: # if already existing Incoming (based on name) should be reused, when existing only ContentObject is created inside
         verify-procedure-name-pattern: # verifies target procedure name matches this pattern, only applies to type procedure_incoming
         metadata-subject: # enables Incoming subject be built from metadata file
       content_object:
@@ -93,7 +94,7 @@ s/<regex>/<substitution>/<options>
 
 The pattern is applied as following:
 - `<regex>` is applied to input (filename without extension)
-  - The extension is re-added where required
+  - The extension is re-added where required (e.g. for the ContentObject name, as that is used to determine the file type)
 - Build substitution values
   - Matching groups of regex are available via name and index
   - If option `m` is present metadata file is loaded

--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -85,14 +85,15 @@ swim:
 
 ### Pattern
 
-The fields `filename-coo-pattern`, `incoming-name-pattern`, `filename-overwrite-pattern` and `verify-procedure-name-pattern` require a specific syntax (inspired by the sed command and regex substitution).
+The `*-pattern`-fields require a specific syntax (inspired by the sed command and regex substitution).
 
 ```
 s/<regex>/<substitution>/<options>
 ```
 
 The pattern is applied as following:
-- `<regex>` is applied to input
+- `<regex>` is applied to input (filename without extension)
+  - The extension is re-added where required
 - Build substitution values
   - Matching groups of regex are available via name and index
   - If option `m` is present metadata file is loaded
@@ -100,10 +101,10 @@ The pattern is applied as following:
 - Evaluate `<substitution>` and inject collected substitution values
 
 Example:
-- Filename: `Test-File.pdf`
+- Filename: `Test-File.pdf` -> Input: `Test-File`
 - Pattern: `s/^(.+)-(.+)$/${1}_${if.CustomValue}_${2}/m`
 - Metadata file: `{"Document" : { "IndexFields" : [{ "Name": "CustomValue", "Value": "ExampleValue" }] } }`
-- Result: `Test_ExampleValue_File.pdf`
+- Result: `Test_ExampleValue_File`
 
 ### Type
 

--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -26,7 +26,7 @@
         <!-- Core Frameworks -->
         <spring-cloud-dependencies.version>2024.0.0</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
         <refarch-dms-integration-fabasoft-rest-api.version>1.4.1</refarch-dms-integration-fabasoft-rest-api.version>
-        <swim-handler-core.version>0.2.0</swim-handler-core.version>
+        <swim-handler-core.version>0.3.0</swim-handler-core.version>
 
         <!-- Logging -->
         <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -99,7 +99,8 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         // check target procedure name
         if (Strings.isNotBlank(useCase.getIncoming().getVerifyProcedureNamePattern())) {
             final String procedureName = this.dmsOutPort.getProcedureName(dmsTarget);
-            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getIncoming().getVerifyProcedureNamePattern(), file.getFileNameWithoutExtension(),
+            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getIncoming().getVerifyProcedureNamePattern(),
+                    file.getFileNameWithoutExtension(),
                     metadata);
             if (!procedureName.toLowerCase(Locale.ROOT).contains(resolvedPattern.toLowerCase(Locale.ROOT))) {
                 final String message = String.format("Procedure name %s doesn't contain resolved pattern %s", procedureName, resolvedPattern);

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -96,12 +96,10 @@ public class ProcessFileUseCase implements ProcessFileInPort {
      */
     protected void processProcedureIncoming(final File file, final UseCase useCase, final DmsTarget dmsTarget,
             final InputStream fileStream, final Metadata metadata) throws MetadataException {
-        final String filename = file.getFileName();
-        final String filenameWithoutExtension = filename.substring(0, filename.lastIndexOf('.'));
         // check target procedure name
         if (Strings.isNotBlank(useCase.getIncoming().getVerifyProcedureNamePattern())) {
             final String procedureName = this.dmsOutPort.getProcedureName(dmsTarget);
-            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getIncoming().getVerifyProcedureNamePattern(), filenameWithoutExtension,
+            final String resolvedPattern = this.patternHelper.applyPattern(useCase.getIncoming().getVerifyProcedureNamePattern(), file.getFileNameWithoutExtension(),
                     metadata);
             if (!procedureName.toLowerCase(Locale.ROOT).contains(resolvedPattern.toLowerCase(Locale.ROOT))) {
                 final String message = String.format("Procedure name %s doesn't contain resolved pattern %s", procedureName, resolvedPattern);
@@ -193,12 +191,13 @@ public class ProcessFileUseCase implements ProcessFileInPort {
     protected DmsContentObjectRequest resolveContentObjectParameters(final File file, final UseCase useCase,
             final Metadata metadata) {
         // resolve ContentObject name
-        final String contentObjectName = this.patternHelper.applyPattern(useCase.getContentObject().getFilenameOverwritePattern(), file.getFileName(),
-                metadata);
+        final String contentObjectName = String.format("%s.%s",
+                this.patternHelper.applyPattern(useCase.getContentObject().getFilenameOverwritePattern(), file.getFileNameWithoutExtension(), metadata),
+                file.getFileExtension());
         // resolve ContentObject subject
         final String contentObjectSubjectPattern = useCase.getContentObject().getSubjectPattern();
         final String contentObjectSubject = Strings.isNotBlank(contentObjectSubjectPattern)
-                ? this.patternHelper.applyPattern(contentObjectSubjectPattern, file.getFileName(), metadata)
+                ? this.patternHelper.applyPattern(contentObjectSubjectPattern, file.getFileNameWithoutExtension(), metadata)
                 : null;
         return new DmsContentObjectRequest(contentObjectName, contentObjectSubject);
     }
@@ -221,12 +220,10 @@ public class ProcessFileUseCase implements ProcessFileInPort {
             // use resolved ContentObject name (filename) if no pattern for Incoming name is defined
             // resolved in this case means the UseCase#filenameOverwritePattern is applied first
             // extension is removed
-            incomingName = contentObjectRequest.name().substring(0, contentObjectRequest.name().lastIndexOf('.'));
+            incomingName = contentObjectRequest.getNameWithoutExtension();
         } else {
             // else apply pattern to original filename
-            final String filename = file.getFileName();
-            final String filenameWithoutExtension = filename.substring(0, filename.lastIndexOf('.'));
-            incomingName = this.patternHelper.applyPattern(useCase.getIncoming().getIncomingNamePattern(), filenameWithoutExtension, metadata);
+            incomingName = this.patternHelper.applyPattern(useCase.getIncoming().getIncomingNamePattern(), file.getFileNameWithoutExtension(), metadata);
         }
         // resolve subject for Incoming;
         final String incomingSubject;

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
@@ -15,7 +15,10 @@ public record DmsContentObjectRequest(@NotBlank String name, String subject) {
      * @return The name without the file extension.
      */
     public String getNameWithoutExtension() {
-        int lastDotIndex = name.lastIndexOf('.');
-        return lastDotIndex != -1 ? name.substring(0, lastDotIndex) : name;
+        final int lastDotIndex = name.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return name;
+        }
+        return name.substring(0, lastDotIndex);
     }
 }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
@@ -15,6 +15,7 @@ public record DmsContentObjectRequest(@NotBlank String name, String subject) {
      * @return The name without the file extension.
      */
     public String getNameWithoutExtension() {
-        return name.substring(0, name.lastIndexOf('.'));
+        int lastDotIndex = name.lastIndexOf('.');
+        return lastDotIndex != -1 ? name.substring(0, lastDotIndex) : name;
     }
 }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsContentObjectRequest.java
@@ -2,5 +2,19 @@ package de.muenchen.oss.swim.dms.domain.model;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * Properties for creating a new ContentObject.
+ *
+ * @param name The name of the new ContentObject including the file extension.
+ * @param subject The subject of the new ContentObject.
+ */
 public record DmsContentObjectRequest(@NotBlank String name, String subject) {
+    /**
+     * Get the name without the file extension.
+     *
+     * @return The name without the file extension.
+     */
+    public String getNameWithoutExtension() {
+        return name.substring(0, name.lastIndexOf('.'));
+    }
 }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsIncomingRequest.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/DmsIncomingRequest.java
@@ -2,5 +2,12 @@ package de.muenchen.oss.swim.dms.domain.model;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * Properties for creating a new Incoming with a ContentObject.
+ *
+ * @param name The name of the new Incoming.
+ * @param subject The subject of the new Incoming.
+ * @param contentObject The properties for the new ContentObject created inside the Incoming.
+ */
 public record DmsIncomingRequest(@NotBlank String name, String subject, DmsContentObjectRequest contentObject) {
 }

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -152,6 +152,7 @@ class ProcessFileUseCaseTest {
     @Test
     void testProcessFile_StaticIncoming() throws UnknownUseCaseException, PresignedUrlException, MetadataException {
         final String useCaseName = "static-incoming";
+        final String overwrittenIncomingName = "asd";
         final String overwrittenContentObjectName = "test-asd.pdf";
         // setup
         when(fileSystemOutPort.getPresignedUrlFile(eq(METADATA_PRESIGNED_URL)))
@@ -160,7 +161,7 @@ class ProcessFileUseCaseTest {
         processFileUseCase.processFile(buildFileEvent(useCaseName, METADATA_PRESIGNED_URL), FILE);
         // test
         final String incomingSubject = "TestKey_1: Test_Value_1\nTestKey_2: Test_Value_2";
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, STATIC_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, incomingSubject, overwrittenContentObjectName);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, STATIC_DMS_TARGET, overwrittenIncomingName, incomingSubject, overwrittenContentObjectName);
         verify(dmsOutPort, times(0)).getProcedureName(any());
         verify(dmsOutPort, times(0)).getIncomingCooByName(any(), any());
     }

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -36,7 +36,7 @@ swim:
       content-object:
         filename-overwrite-pattern: "s/^(.+)(?:-COO.[^-]+-)(.+)$/\\${1}-\\${2}/"
       incoming:
-        incoming-name-pattern: "s/^(.+)(?:-COO.[^-]+-).+$/\\${1}/"
+        incoming-name-pattern: "s/^(.+)(?:-COO.[^-]+-)(.+)$/\\${2}/"
         metadata-subject: true
       context:
         username: staticUsername


### PR DESCRIPTION
**Description**

Dms unify pattern input by always using filename without extension.

Requires https://github.com/it-at-m/swim/pull/156

**Reference**

Issues closes #155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded a core dependency to incorporate the latest improvements.

- **Refactor**
  - Streamlined file naming extraction to ensure consistent processing across the service.

- **New Features**
  - Introduced a capability to retrieve file names without their extensions for clearer file handling.
  - Added a configuration option to reuse existing Incoming records with the same name.

- **Documentation**
  - Clarified and updated file-naming pattern guidelines to make configuration and usage more intuitive.
  - Expanded explanations on regex application for improved understanding of file processing.
  - Added detailed documentation for properties in incoming request records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->