### PR TITLE
bug/dispatch fix copy object replace tag

### DIFF
--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -263,7 +263,11 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
                     .source(copySource)
                     .object(destPath);
             if (clearTags) {
-                copyObjectArgs.taggingDirective(Directive.REPLACE).tags(Map.of());
+                copyObjectArgs.taggingDirective(Directive.REPLACE);
+                // workaround as empty tags are not set as header by minio but required
+                copyObjectArgs.extraHeaders(Map.of(
+                        "x-amz-tagging", ""
+                ));
             }
             this.minioClient.copyObject(copyObjectArgs.build());
             log.info("Copied file {} from bucket {} to {} in bucket {}", srcPath, srcBucket, destPath, destBucket);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -266,8 +266,7 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
                 copyObjectArgs.taggingDirective(Directive.REPLACE);
                 // workaround as empty tags are not set as header by minio but required
                 copyObjectArgs.extraHeaders(Map.of(
-                        "x-amz-tagging", ""
-                ));
+                        "x-amz-tagging", ""));
             }
             this.minioClient.copyObject(copyObjectArgs.build());
             log.info("Copied file {} from bucket {} to {} in bucket {}", srcPath, srcBucket, destPath, destBucket);


### PR DESCRIPTION
**Description**

Dispatch add workaround for copy object replace tags as minio doesn't set empty tags as header.

**References**

- https://github.com/minio/minio-java/issues/1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced file transfer operations by refining how metadata tags are managed when they are cleared. This update ensures improved consistency and reliability when interacting with our cloud storage service, resulting in smoother file handling experiences for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->