### PR TITLE
conf/kafka retry once

### DIFF
--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     stream:
       default:
         consumer:
-          max-attempts: 3
+          max-attempts: 1
       kafka:
         default:
           consumer:

--- a/dms-service/src/main/resources/application.yml
+++ b/dms-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     stream:
       default:
         consumer:
-          max-attempts: 3
+          max-attempts: 1
       kafka:
         default:
           consumer:

--- a/invoice-service/src/main/resources/application.yml
+++ b/invoice-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     stream:
       default:
         consumer:
-          max-attempts: 3
+          max-attempts: 1
       kafka:
         default:
           consumer:


### PR DESCRIPTION
**Description**

Set kafka retry to one instead of three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the number of retry attempts for message processing from 3 to 1 across multiple services, resulting in faster handling of failed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->