### PR TITLE
conf(ci): use v1.0.14 of lhm_actions

### DIFF
--- a/.github/workflows/maven-node-build.yaml
+++ b/.github/workflows/maven-node-build.yaml
@@ -24,16 +24,16 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - if: ${{ hashFiles(format('./{0}/package.json', matrix.app-path)) != null }}
         id: node
-        uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build@main
+        uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build@17061b55c5c6df8fa9934d6488d7d29781c24343 # v1.0.14
         with:
           app-path: "${{ matrix.app-path }}"
       - if: ${{ hashFiles(format('./{0}/pom.xml', matrix.app-path)) != null }}
         id: maven
-        uses: it-at-m/lhm_actions/action-templates/actions/action-maven-build@main
+        uses: it-at-m/lhm_actions/action-templates/actions/action-maven-build@17061b55c5c6df8fa9934d6488d7d29781c24343 # v1.0.14
         with:
           app-path: "${{ matrix.app-path }}"
       - if: github.ref == 'refs/heads/main' && matrix.build-image
-        uses: it-at-m/lhm_actions/action-templates/actions/action-build-image@main
+        uses: it-at-m/lhm_actions/action-templates/actions/action-build-image@17061b55c5c6df8fa9934d6488d7d29781c24343 # v1.0.14
         with:
           path: "${{ matrix.app-path }}"
           image-name: "${{ matrix.app-path }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Maven build and release
         id: maven-release-step
-        uses: it-at-m/lhm_actions/action-templates/actions/action-maven-release@7863642bb665a1d1994b2c2645db6e64a1a694ad # v1.0.9
+        uses: it-at-m/lhm_actions/action-templates/actions/action-maven-release@17061b55c5c6df8fa9934d6488d7d29781c24343 # v1.0.14
         with:
           app-path: ${{ inputs.module }}
           releaseVersion: ${{ inputs.release-version }}


### PR DESCRIPTION
**Description**

CI pin lhm_actions and bump to v1.0.14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build and release workflows to use fixed versions of key GitHub Actions, ensuring more consistent and reliable automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->