### PR TITLE
fix(dms): incoming subject default null

### DIFF
--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -231,7 +231,7 @@ public class ProcessFileUseCase implements ProcessFileInPort {
         if (useCase.getIncoming().isMetadataSubject()) {
             incomingSubject = this.subjectFromMetadata(metadata);
         } else {
-            incomingSubject = incomingName;
+            incomingSubject = null;
         }
         return new DmsIncomingRequest(incomingName, incomingSubject, contentObjectRequest);
     }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
@@ -20,23 +20,27 @@ public class UseCase {
     /**
      * Defines how the target coo is gathered.
      */
-    @NotNull @Valid
+    @NotNull
+    @Valid
     private UseCaseSource cooSource;
     /**
      * Properties for creating an Incoming.
      * Applies to {@link UseCaseType#PROCEDURE_INCOMING}.
      */
-    @NotNull @Valid
+    @NotNull
+    @Valid
     private UseCaseIncoming incoming = new UseCaseIncoming();
     /**
      * Properties for creating a ContentObject.
      * Applies to {@link UseCaseType#PROCEDURE_INCOMING} and {@link UseCaseType#PROCEDURE_INCOMING}.
      */
-    @NotNull @Valid
+    @NotNull
+    @Valid
     private UseCaseContentObject contentObject = new UseCaseContentObject();
     /**
      * Context under which DMS requests are made.
      */
-    @NotNull @Valid
+    @NotNull
+    @Valid
     private DmsRequestContext context = new DmsRequestContext(null, null, null);
 }

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/domain/model/UseCase.java
@@ -1,10 +1,13 @@
 package de.muenchen.oss.swim.dms.domain.model;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.springframework.validation.annotation.Validated;
 
 @Data
+@Validated
 public class UseCase {
     @NotBlank
     private String name;
@@ -17,23 +20,23 @@ public class UseCase {
     /**
      * Defines how the target coo is gathered.
      */
-    @NotNull
+    @NotNull @Valid
     private UseCaseSource cooSource;
     /**
      * Properties for creating an Incoming.
      * Applies to {@link UseCaseType#PROCEDURE_INCOMING}.
      */
-    @NotNull
+    @NotNull @Valid
     private UseCaseIncoming incoming = new UseCaseIncoming();
     /**
      * Properties for creating a ContentObject.
      * Applies to {@link UseCaseType#PROCEDURE_INCOMING} and {@link UseCaseType#PROCEDURE_INCOMING}.
      */
-    @NotNull
+    @NotNull @Valid
     private UseCaseContentObject contentObject = new UseCaseContentObject();
     /**
      * Context under which DMS requests are made.
      */
-    @NotNull
+    @NotNull @Valid
     private DmsRequestContext context = new DmsRequestContext(null, null, null);
 }

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -126,7 +126,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION,
+        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(FILE_NAME_WITHOUT_EXTENSION, null,
                 new DmsContentObjectRequest(FILE_NAME, null));
         verify(dmsOutPort, times(1)).createIncomingInInbox(eq(STATIC_DMS_TARGET), eq(incomingRequest), eq(null));
     }
@@ -144,7 +144,7 @@ class ProcessFileUseCaseTest {
         verify(targetResolverHelper, times(1)).resolveTypeFromMetadataFile(any());
         verify(targetResolverHelper, times(1)).resolveTargetCoo(eq(UseCaseType.PROCEDURE_INCOMING), any(), eq(useCase), eq(FILE));
         verify(dmsMetadataHelper, times(1)).resolveIncomingDmsTarget(any());
-        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION,
+        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(FILE_NAME_WITHOUT_EXTENSION, null,
                 new DmsContentObjectRequest(FILE_NAME, null));
         verify(dmsOutPort, times(1)).createProcedureIncoming(eq(METADATA_DMS_TARGET_INCOMING), eq(incomingRequest), eq(null));
     }
@@ -172,7 +172,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, null, FILE_NAME);
     }
 
     @Test
@@ -181,7 +181,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, null, FILE_NAME);
         // call catch all
         final String fileNameWithoutExtension = "asd";
         final String fileName = String.format("%s.pdf", fileNameWithoutExtension);
@@ -192,7 +192,7 @@ class ProcessFileUseCaseTest {
         processFileUseCase.processFile(new FileEvent(useCaseName, presignedUrl, null), file);
         final DmsTarget dmsTarget = new DmsTarget("COO.321.321.321", useCase.getContext());
         // test catche all
-        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(fileNameWithoutExtension, fileNameWithoutExtension,
+        final DmsIncomingRequest incomingRequest = new DmsIncomingRequest(fileNameWithoutExtension, null,
                 new DmsContentObjectRequest(fileName, null));
         verify(dmsOutPort, times(1)).createProcedureIncoming(eq(dmsTarget), eq(incomingRequest), eq(null));
     }
@@ -204,7 +204,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, null, FILE_NAME);
         verify(dmsOutPort, times(1)).findObjectsByName(eq(DmsResourceType.PROCEDURE), eq(PATTERN_VALUE_TEST), any());
     }
 
@@ -216,7 +216,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME_WITHOUT_EXTENSION, FILE_NAME);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, null, FILE_NAME);
         verify(dmsOutPort, times(1)).getProcedureName(eq(FILENAME_DMS_TARGET));
         // setup failure
         when(dmsOutPort.getProcedureName(eq(FILENAME_DMS_TARGET))).thenReturn("asd");
@@ -233,7 +233,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, null), FILE);
         // test
-        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, OVERWRITTEN_INCOMING_NAME, FILE_NAME);
+        testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, OVERWRITTEN_INCOMING_NAME, null, FILE_NAME);
         verify(dmsOutPort, times(1)).getIncomingCooByName(eq(FILENAME_DMS_TARGET), eq(OVERWRITTEN_INCOMING_NAME));
         // setup reuse
         when(dmsOutPort.getIncomingCooByName(eq(FILENAME_DMS_TARGET), eq(OVERWRITTEN_INCOMING_NAME))).thenReturn(Optional.of("COO.321.321.321"));


### PR DESCRIPTION
**Description**

- dms: use incoming subject null by default

**Reference**

https://github.com/it-at-m/swim/pull/209#discussion_r2087078767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved validation for use cases, ensuring that all nested objects are now validated for correctness.

- **Bug Fixes**
  - Adjusted the handling of subjects in incoming requests to prevent unintended fallback values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->