### PR TITLE
refact(dms): change metadata subject pattern

### DIFF
--- a/dispatch-service/src/main/resources/application-local.yml
+++ b/dispatch-service/src/main/resources/application-local.yml
@@ -54,6 +54,16 @@ swim:
       destination-binding: dms-out
       mail-addresses:
         - test-meta@example.com
+    - name: test-inbox-incoming
+      bucket: swim-bucket
+      path: test-inbox-incoming
+      required-tags:
+        SWIM_State: processed
+      requires-metadata: true
+      recursive: true
+      destination-binding: dms-out
+      mail-addresses:
+        - test@example.com
     - name: test
       bucket: swim-bucket
       path: test

--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -118,8 +118,8 @@ The metadata file is used for following different functions:
     - The dms target can be resolved via metadata file, see [Coo source](#coo-source) `metadata_file`
     - A valid metadata file in this case requires either personal `PPK_` or group `GPK_` inbox values defined (empty values are ignored) for `type: inbox` or `VG_` values for incoming or coo work queue. See [Configuration](#configuration).
 - Subject
-  - Values starting with `PdE_` (default) could be set as subject (see [Configuration](#configuration) `metadata-subject: true` and `metadata-subject-prefix`).
-  - The below example would lead to a subject `ExampleKey1: Example Value 1\nExampleKey2: Example Value 2`.
+  - Values starting with `FdE_` (default) could be set as subject (see [Configuration](#configuration) `metadata-subject: true` and `metadata-subject-prefix`).
+  - The below example would lead to a subject `Example Value 1 (ExampleKey1)\nExample Value 2 (ExampleKey2)`.
 - Target type
   - The target resource type is resolved via metadata file. See [Configuration](#configuration) `metadata-dms-target-key` and [Type](#type) `metadata_file`.
   - Allowed values in metadata file are all use case [Types](#type) except `metadata_file` (e.g. `inbox_content_object`).
@@ -167,11 +167,11 @@ If a metadata file is required but missing or is invalid (syntax, value combinat
         "Value": ""
       },
       {
-        "Name": "PdE_ExampleKey1",
+        "Name": "FdE_ExampleKey1",
         "Value": "Example Value 1"
       },
       {
-        "Name": "PdE_ExampleKey2",
+        "Name": "FdE_ExampleKey2",
         "Value": "Example Value 2"
       }
     ]

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -175,9 +175,9 @@ public class ProcessFileUseCase implements ProcessFileInPort {
                 .sorted(Map.Entry.comparingByKey())
                 // build subject string
                 .map(i -> String.format(
-                        "%s: %s",
-                        i.getKey().replaceFirst("^" + swimDmsProperties.getMetadataSubjectPrefix(), ""),
-                        i.getValue()))
+                        "%s (%s)",
+                        i.getValue(),
+                        i.getKey().replaceFirst("^" + swimDmsProperties.getMetadataSubjectPrefix(), "")))
                 .collect(Collectors.joining("\n"));
     }
 

--- a/dms-service/src/main/resources/application-local.yml
+++ b/dms-service/src/main/resources/application-local.yml
@@ -29,6 +29,13 @@ swim:
       type: inbox_content_object
       coo-source:
         type: metadata_file
+    - name: test-inbox-incoming
+      type: inbox_incoming
+      coo-source:
+        type: metadata_file
+      incoming:
+        incoming-name-pattern: "s/^(.*)$/\\${if.Klassifikation}/m"
+        metadata-subject: true
 #    - name: test
 #      type: incoming_object
 #      coo-source: filename_name

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -160,7 +160,7 @@ class ProcessFileUseCaseTest {
         // call
         processFileUseCase.processFile(buildFileEvent(useCaseName, METADATA_PRESIGNED_URL), FILE);
         // test
-        final String incomingSubject = "TestKey_1: Test_Value_1\nTestKey_2: Test_Value_2";
+        final String incomingSubject = "Test_Value_1 (TestKey_1)\nTest_Value_2 (TestKey_2)";
         testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, STATIC_DMS_TARGET, overwrittenIncomingName, incomingSubject, overwrittenContentObjectName);
         verify(dmsOutPort, times(0)).getProcedureName(any());
         verify(dmsOutPort, times(0)).getIncomingCooByName(any(), any());


### PR DESCRIPTION
**Description**

DMS: Refactor metadata subject pattern, so allow grouping by first letter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the display format of subject strings generated from metadata, now showing values followed by their keys in parentheses (e.g., "Value (Key)").
- **Tests**
  - Adjusted tests to reflect the new subject string format.
- **New Features**
  - Added a new use-case configuration for processing incoming files with specific tagging and notification settings.
- **Documentation**
  - Updated metadata key prefixes and subject formatting examples to align with the new display style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->