### PR TITLE
feat(dms): filename map unicode case regex matching

### DIFF
--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/helper/TargetResolverHelper.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/helper/TargetResolverHelper.java
@@ -69,7 +69,10 @@ public class TargetResolverHelper {
         case FILENAME_MAP -> {
             // find first matching target coo from map
             final String targetCoo = useCase.getCooSource().getFilenameToCoo().entrySet().stream()
-                    .filter(i -> Pattern.compile(i.getKey(), Pattern.CASE_INSENSITIVE).matcher(file.getFileName()).find())
+                    .filter(i -> Pattern.compile(
+                            i.getKey(),
+                            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE)
+                            .matcher(file.getFileName()).find())
                     .findFirst()
                     .map(Map.Entry::getValue)
                     .orElseThrow(() -> new IllegalStateException("No matching filename map entry configured."));

--- a/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
+++ b/dms-service/src/test/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCaseTest.java
@@ -183,9 +183,9 @@ class ProcessFileUseCaseTest {
         // test
         testDefaults(useCaseName, UseCaseType.PROCEDURE_INCOMING, FILENAME_DMS_TARGET, FILE_NAME_WITHOUT_EXTENSION, null, FILE_NAME);
         // call catch all
-        final String fileNameWithoutExtension = "asd";
+        final String fileNameWithoutExtension = "äasd";
         final String fileName = String.format("%s.pdf", fileNameWithoutExtension);
-        final String filePath = "test/asd.pdf";
+        final String filePath = String.format("test/%s", fileName);
         final File file = new File(BUCKET, filePath);
         final String presignedUrl = String.format("http://localhost:9001/%s/%s", BUCKET, filePath);
         final UseCase useCase = swimDmsProperties.findUseCase(useCaseName);

--- a/dms-service/src/test/resources/application-test.yml
+++ b/dms-service/src/test/resources/application-test.yml
@@ -66,7 +66,7 @@ swim:
         type: filename_map
         filename-to-coo:
           "[^test.*]": "COO.123.123.123"
-          "[.*]": "COO.321.321.321"
+          "[^Ä.*]": "COO.321.321.321"
       context:
         username: staticUsername
         joboe: staticJobOe


### PR DESCRIPTION
**Description**

DMS coo source filename map support unicode case insensitive matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename matching to support case-insensitive Unicode characters.

* **Tests**
  * Updated test cases to include filenames with Unicode characters for more comprehensive validation.

* **Chores**
  * Refined configuration patterns to more precisely control filename mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->