### PR TITLE
feat(dms): fallback empty pattern incoming name result

### DIFF
--- a/dms-service/README.md
+++ b/dms-service/README.md
@@ -75,7 +75,7 @@ swim:
         joboe: # used to resolve user role under which the DMS action is executed, default role if not defined
         jobposition: # used to resolve user role under which the DMS action is executed, default role if not defined
       incoming:
-        incoming-name-pattern: # overwrite Incoming name via Regex pattern
+        incoming-name-pattern: # overwrite Incoming name via Regex pattern, if result is empty falls back to default filename without extension
         reuse-incoming: # if already existing Incoming (based on name) should be reused, when existing only ContentObject is created inside
         verify-procedure-name-pattern: # verifies target procedure name matches this pattern, only applies to type procedure_incoming
         metadata-subject: # enables Incoming subject be built from metadata file

--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/application/usecase/ProcessFileUseCase.java
@@ -224,9 +224,13 @@ public class ProcessFileUseCase implements ProcessFileInPort {
             incomingName = contentObjectRequest.getNameWithoutExtension();
         } else {
             // else apply pattern to original filename
-            incomingName = this.patternHelper.applyPattern(useCase.getIncoming().getIncomingNamePattern(), file.getFileNameWithoutExtension(), metadata);
+            final String patternIncomingName = this.patternHelper.applyPattern(useCase.getIncoming().getIncomingNamePattern(),
+                    file.getFileNameWithoutExtension(), metadata);
+            incomingName = StringUtils.isNotBlank(patternIncomingName) ? patternIncomingName :
+            // fallback to default if empty name via pattern
+                    contentObjectRequest.getNameWithoutExtension();
         }
-        // resolve subject for Incoming;
+        // resolve subject for Incoming
         final String incomingSubject;
         if (useCase.getIncoming().isMetadataSubject()) {
             incomingSubject = this.subjectFromMetadata(metadata);


### PR DESCRIPTION
**Description**

DMS: Fallback to default filename without extension for Incoming name if pattern result is empty.

**Reference**

Issues closes #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the behavior of the `incoming-name-pattern` configuration, specifying that if the pattern results in an empty string, the default filename (without extension) will be used as the Incoming name.

* **Bug Fixes**
  * Improved the fallback mechanism for resolving the Incoming name when the pattern produces an empty or blank result.

* **Tests**
  * Added a unit test to verify correct fallback behavior when the incoming name pattern yields an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->