### PR TITLE
fix(dipa): soap client streaming

### DIFF
--- a/dipa-service/pom.xml
+++ b/dipa-service/pom.xml
@@ -140,6 +140,16 @@
             <version>${cxf.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxws</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
             <version>4.0.3</version>

--- a/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
+++ b/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
@@ -4,6 +4,10 @@ import com.fabasoft.schemas.websvc.mucsdipabai_15_1700_giwsd.MUCSDIPABAI151700GI
 import com.fabasoft.schemas.websvc.mucsdipabai_15_1700_giwsd.MUCSDIPABAI151700GIWSDSoap;
 import jakarta.xml.ws.BindingProvider;
 import jakarta.xml.ws.soap.SOAPBinding;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,8 +24,14 @@ class DipaConfiguration {
         ((BindingProvider) soapClient).getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, properties.getEndpointUrl());
         ((BindingProvider) soapClient).getRequestContext().put(BindingProvider.USERNAME_PROPERTY, properties.getUsername());
         ((BindingProvider) soapClient).getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, properties.getPassword());
+        // enable MTOM
         final SOAPBinding binding = (SOAPBinding) ((BindingProvider) soapClient).getBinding();
         binding.setMTOMEnabled(true);
+        // enable chunking
+        final Client client = ClientProxy.getClient(soapClient);
+        HTTPConduit conduit = (HTTPConduit) client.getConduit();
+        HTTPClientPolicy policy = conduit.getClient();
+        policy.setAllowChunking(true);
         return soapClient;
     }
 }

--- a/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
+++ b/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
@@ -33,6 +33,7 @@ class DipaConfiguration {
         final HTTPConduit conduit = (HTTPConduit) client.getConduit();
         final HTTPClientPolicy policy = conduit.getClient();
         policy.setAllowChunking(true);
+        policy.setReceiveTimeout(properties.getSendTimeout().toMillis());
         return soapClient;
     }
 }

--- a/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
+++ b/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaConfiguration.java
@@ -28,9 +28,10 @@ class DipaConfiguration {
         final SOAPBinding binding = (SOAPBinding) ((BindingProvider) soapClient).getBinding();
         binding.setMTOMEnabled(true);
         // enable chunking
+        @SuppressWarnings("PMD.CloseResource")
         final Client client = ClientProxy.getClient(soapClient);
-        HTTPConduit conduit = (HTTPConduit) client.getConduit();
-        HTTPClientPolicy policy = conduit.getClient();
+        final HTTPConduit conduit = (HTTPConduit) client.getConduit();
+        final HTTPClientPolicy policy = conduit.getClient();
         policy.setAllowChunking(true);
         return soapClient;
     }

--- a/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaProperties.java
+++ b/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaProperties.java
@@ -1,10 +1,13 @@
 package de.muenchen.oss.swim.dipa.adapter.out.dipa;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.ToString;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 @ConfigurationProperties("swim.dipa")
 @Data
@@ -17,4 +20,6 @@ class DipaProperties {
     private String username;
     @NotBlank
     private String password;
+    @NotNull
+    private Duration sendTimeout;
 }

--- a/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaProperties.java
+++ b/dipa-service/src/main/java/de/muenchen/oss/swim/dipa/adapter/out/dipa/DipaProperties.java
@@ -2,12 +2,11 @@ package de.muenchen.oss.swim.dipa.adapter.out.dipa;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import lombok.Data;
 import lombok.ToString;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
-
-import java.time.Duration;
 
 @ConfigurationProperties("swim.dipa")
 @Data

--- a/dipa-service/src/main/resources/application.yml
+++ b/dipa-service/src/main/resources/application.yml
@@ -82,3 +82,7 @@ info:
   build:
     java.version: @java.version@
     spring-cloud.version: @spring-cloud-dependencies.version@
+
+swim:
+  dipa:
+    send-timeout: 5m

--- a/dipa-service/src/main/resources/dipa_mtom.wsdl
+++ b/dipa-service/src/main/resources/dipa_mtom.wsdl
@@ -32,7 +32,7 @@
                     <xs:element minOccurs="0" maxOccurs="1" name="MUCSDIPABAI_15_1700_filename" type="xs:string"/>
                     <xs:element minOccurs="0" maxOccurs="1" name="MUCSDIPABAI_15_1700_fileextension" type="xs:string"/>
                     <xs:element minOccurs="0" maxOccurs="1" name="MUCSDIPABAI_15_1700_filecontent"
-                                type="xs:base64Binary" xmime:expectedContentTypes="application/pdf"/>
+                                type="xs:base64Binary" xmime:expectedContentTypes="application/octet-stream"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="ArrayOfMUCSDIPABAI_15_1700_GIAttachmentType">


### PR DESCRIPTION
**Description**

DiPa: Fix SOAP client use chunking to support e2e streaming

**Reference**

- [Apache CXF docs](https://cxf.apache.org/docs/client-http-transport-including-ssl-support.html#ClientHTTPTransport(includingSSLsupport)-HowtoconfiguretheHTTPConduitfortheSOAPClient?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for SOAP client timeout and HTTP chunking for improved performance and reliability.
  * Introduced a new application setting to configure SOAP client send timeout.

* **Bug Fixes**
  * Updated WSDL schema to accept a broader range of file content types for attachments.

* **Chores**
  * Added necessary dependencies to support enhanced SOAP client features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->