### PR TITLE
fix(dispatcher): reroute tag protocol processed

### DIFF
--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUseCase.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUseCase.java
@@ -285,6 +285,11 @@ public class DispatcherUseCase implements DispatcherInPort {
         final String rawPath = useCase.getRawPath(swimDispatcherProperties, file.path());
         final String destPath = String.format("%s/from_%s/%s", targetUseCase.getDispatchPath(swimDispatcherProperties), useCase.getName(), rawPath);
         fileSystemOutPort.copyFile(file.bucket(), file.path(), targetUseCase.getBucket(), destPath, true);
+        // tag protocol processed if enabled
+        if (targetUseCase.isTagProtocolProcessed()) {
+            fileSystemOutPort.tagFile(targetUseCase.getBucket(), destPath, Map.of(
+                    swimDispatcherProperties.getDispatchStateTagKey(), swimDispatcherProperties.getProtocolProcessedFilesStateTagValue()));
+        }
         // finish file
         this.finishFile(useCase, file);
         log.info("File {} in bucket {} rerouted from use case {} to use case {}", file.path(), file.bucket(), useCase.getName(), targetUseCase.getName());

--- a/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUseCaseTest.java
+++ b/dispatch-service/src/test/java/de/muenchen/oss/swim/dispatcher/application/usecase/DispatcherUseCaseTest.java
@@ -196,6 +196,8 @@ class DispatcherUseCaseTest {
         verify(dispatcherUseCase, times(1)).rerouteFileToUseCase(eq(useCase), eq(FILE1), eq(tags));
         verify(fileSystemOutPort, times(1)).copyFile(eq(BUCKET), eq(FILE1.path()), eq("test-bucket-2"),
                 eq("path/test2/inProcess/from_test-meta/path/test.pdf"), eq(true));
+        verify(fileSystemOutPort, times(1)).tagFile(eq("test-bucket-2"), eq("path/test2/inProcess/from_test-meta/path/test.pdf"), eq(Map.of(
+                "SWIM_State", "protocolProcessingSuccessful")));
         verify(fileHandlingHelper, times(1)).finishFile(eq(useCase), eq(BUCKET), eq(FILE1.path()));
         verify(dispatchMeter, times(1)).incrementDispatched(eq(USE_CASE), eq(REROUTE.name()));
     }


### PR DESCRIPTION
**Description**

- fix(dispatcher): reroute set protocol processed tag if target use case has it enabled

**Reference**

Issues closes #347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rerouted files can now be automatically tagged with protocol processing status when configured, enabling better visibility of file states in the dispatch workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->