### PR TITLE
fix(dispatcher): finishing events with metadata file

### DIFF
--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
@@ -12,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
@@ -32,9 +31,6 @@ public class StreamingInAdapter {
                 for (final PresignedFile file : multiFileEvent.files()) {
                     final String useCase = multiFileEvent.useCase();
                     markFileFinishedInPort.markFileFinished(useCase, file.presignedUrl());
-                    if (StringUtils.isNotBlank(file.metadataPresignedUrl())) {
-                        markFileFinishedInPort.markFileFinished(useCase, file.metadataPresignedUrl());
-                    }
                 }
             } catch (PresignedUrlException | UseCaseException e) {
                 throw new RuntimeException(e);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/helper/FileHandlingHelper.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/application/usecase/helper/FileHandlingHelper.java
@@ -46,6 +46,7 @@ public class FileHandlingHelper {
 
     /**
      * Tag file and move to finished directory.
+     * The metadata file is also handled if {@link UseCase#isRequiresMetadata()} and file exists.
      *
      * @param useCase The use case of the file.
      * @param file The file to finish.


### PR DESCRIPTION
**Description**

- fix(dispatcher): fix broken finishing of events with metadata file

**Reference**
Introduced with #376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file completion handling so that only the primary file URL is marked as finished.
  * Ensured metadata files continue to be processed when required and available.

* **Documentation**
  * Clarified the file completion flow and metadata processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->