### PR TITLE
refact(handler,dispatcher): replace FileEvent helper methods

### DIFF
--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
@@ -25,9 +25,9 @@ public class StreamingInAdapter {
     protected Consumer<Message<FileEvent>> finished() {
         return fileEventMessage -> {
             final FileEvent event = fileEventMessage.getPayload();
+            final String useCase = event.useCase();
             try {
                 for (final PresignedFile file : event.files()) {
-                    final String useCase = event.useCase();
                     markFileFinishedInPort.markFileFinished(useCase, file.presignedUrl());
                 }
             } catch (PresignedUrlException | UseCaseException e) {
@@ -41,8 +41,9 @@ public class StreamingInAdapter {
         return fileEventMessage -> {
             final FileEvent event = fileEventMessage.getPayload();
             final ErrorDetails error = this.errorDetailsFromHeaders(fileEventMessage.getHeaders());
+            final String useCase = event.useCase();
             for (final PresignedFile file : event.files()) {
-                errorHandlerInPort.handleError(event.useCase(), file, error);
+                errorHandlerInPort.handleError(useCase, file, error);
             }
         };
     }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/in/streaming/StreamingInAdapter.java
@@ -7,7 +7,6 @@ import de.muenchen.oss.swim.dispatcher.domain.exception.UseCaseException;
 import de.muenchen.oss.swim.dispatcher.domain.model.ErrorDetails;
 import de.muenchen.oss.swim.dispatcher.domain.model.PresignedFile;
 import de.muenchen.oss.swim.dispatcher.domain.model.streaming.FileEvent;
-import de.muenchen.oss.swim.dispatcher.domain.model.streaming.MultiFileEvent;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -26,10 +25,9 @@ public class StreamingInAdapter {
     protected Consumer<Message<FileEvent>> finished() {
         return fileEventMessage -> {
             final FileEvent event = fileEventMessage.getPayload();
-            final MultiFileEvent multiFileEvent = MultiFileEvent.fromFileEvent(event);
             try {
-                for (final PresignedFile file : multiFileEvent.files()) {
-                    final String useCase = multiFileEvent.useCase();
+                for (final PresignedFile file : event.files()) {
+                    final String useCase = event.useCase();
                     markFileFinishedInPort.markFileFinished(useCase, file.presignedUrl());
                 }
             } catch (PresignedUrlException | UseCaseException e) {
@@ -42,10 +40,9 @@ public class StreamingInAdapter {
     protected Consumer<Message<FileEvent>> dlq() {
         return fileEventMessage -> {
             final FileEvent event = fileEventMessage.getPayload();
-            final MultiFileEvent multiFileEvent = MultiFileEvent.fromFileEvent(event);
             final ErrorDetails error = this.errorDetailsFromHeaders(fileEventMessage.getHeaders());
-            for (final PresignedFile file : multiFileEvent.files()) {
-                errorHandlerInPort.handleError(multiFileEvent.useCase(), file, error);
+            for (final PresignedFile file : event.files()) {
+                errorHandlerInPort.handleError(event.useCase(), file, error);
             }
         };
     }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/configuration/EventMessageConverter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/configuration/EventMessageConverter.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Component;
 /**
  * Spring {@link MessageConverter} that converts to and from {@link FileEvent}
  * implementations based on a discriminator header.
+ * <p>
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * <p>
  * When the requested target type is {@code FileEvent}, the converter inspects the

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/FileEvent.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/FileEvent.java
@@ -1,5 +1,11 @@
 package de.muenchen.oss.swim.dispatcher.domain.model.streaming;
 
+import de.muenchen.oss.swim.dispatcher.domain.model.PresignedFile;
+import java.util.List;
+
 public sealed interface FileEvent
         permits SingleFileEvent, MultiFileEvent {
+    String useCase();
+
+    List<PresignedFile> files();
 }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/MultiFileEvent.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/MultiFileEvent.java
@@ -8,6 +8,14 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+/**
+ * Event for processing multiple files.
+ * <p>
+ * ATTENTION: This class need to match the one in the dispatch-service.
+ *
+ * @param useCase The use case of the event.
+ * @param files The files to process.
+ */
 public record MultiFileEvent(
         @NotBlank String useCase,
         @NotEmpty List<@NotNull @Valid PresignedFile> files) implements FileEvent {
@@ -19,16 +27,6 @@ public record MultiFileEvent(
         }
         if (files == null || files.isEmpty()) {
             throw new IllegalArgumentException("files must not be null or empty");
-        }
-    }
-
-    public static MultiFileEvent fromFileEvent(final FileEvent fileEvent) {
-        if (fileEvent instanceof MultiFileEvent multi) {
-            return multi;
-        } else if (fileEvent instanceof SingleFileEvent(String sUc, PresignedFile sPf)) {
-            return new MultiFileEvent(sUc, List.of(sPf));
-        } else {
-            throw new IllegalArgumentException("Message payload is no valid event but '%s'".formatted(fileEvent.getClass()));
         }
     }
 }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/MultiFileEvent.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/MultiFileEvent.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Event for processing multiple files.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * @param useCase The use case of the event.
  * @param files The files to process.

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/SingleFileEvent.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/SingleFileEvent.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Event for processing a single file.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * @param useCase The use case of the event.
  * @param file The file to process.
@@ -27,7 +27,7 @@ public record SingleFileEvent(
             throw new IllegalArgumentException("useCase must not be null or blank");
         }
         if (file == null) {
-            throw new IllegalArgumentException("presignedUrl must not be null");
+            throw new IllegalArgumentException("file must not be null");
         }
     }
 

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/SingleFileEvent.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/domain/model/streaming/SingleFileEvent.java
@@ -6,9 +6,19 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
+/**
+ * Event for processing a single file.
+ * <p>
+ * ATTENTION: This class need to match the one in the dispatch-service.
+ *
+ * @param useCase The use case of the event.
+ * @param file The file to process.
+ */
 public record SingleFileEvent(
         @NotBlank String useCase,
-        @JsonUnwrapped @NotNull @Valid PresignedFile presignedFile) implements FileEvent {
+        @JsonUnwrapped @NotNull @Valid PresignedFile file) implements FileEvent {
 
     public static final String TYPE_NAME = "single";
 
@@ -16,8 +26,13 @@ public record SingleFileEvent(
         if (useCase == null || useCase.isBlank()) {
             throw new IllegalArgumentException("useCase must not be null or blank");
         }
-        if (presignedFile == null) {
+        if (file == null) {
             throw new IllegalArgumentException("presignedUrl must not be null");
         }
+    }
+
+    @Override
+    public List<PresignedFile> files() {
+        return List.of(file);
     }
 }

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/configuration/EventMessageConverter.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/configuration/EventMessageConverter.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
  * Spring {@link MessageConverter} that converts to and from {@link FileEvent}
  * implementations based on a discriminator header.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * <p>
  * When the requested target type is {@code FileEvent}, the converter inspects the

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/FileEvent.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/FileEvent.java
@@ -1,6 +1,10 @@
 package de.muenchen.oss.swim.libs.handlercore.domain.model;
 
+import java.util.List;
+
 public sealed interface FileEvent
         permits SingleFileEvent, MultiFileEvent {
     String useCase();
+
+    List<PresignedFile> files();
 }

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/MultiFileEvent.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/MultiFileEvent.java
@@ -19,14 +19,4 @@ public record MultiFileEvent(
         @NotBlank String useCase,
         @NotEmpty List<@NotNull @Valid PresignedFile> files) implements FileEvent {
     public static final String TYPE_NAME = "multi";
-
-    public static MultiFileEvent fromFileEvent(final FileEvent fileEvent) {
-        if (fileEvent instanceof MultiFileEvent multi) {
-            return multi;
-        } else if (fileEvent instanceof SingleFileEvent(String sUc, PresignedFile sPf)) {
-            return new MultiFileEvent(sUc, List.of(sPf));
-        } else {
-            throw new IllegalArgumentException("Message payload is no valid event but '%s'".formatted(fileEvent.getClass()));
-        }
-    }
 }

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/MultiFileEvent.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/MultiFileEvent.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Event for processing multiple files.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * @param useCase The use case of the event.
  * @param files The files to process.

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/PresignedFile.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/PresignedFile.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
  * Container for presigned URLs for a single file.
  * Optional with presigned URL for the according metadata file.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * @param presignedUrl The presigned URL of the file.
  * @param metadataPresignedUrl The presigned URL of the according metadata file.

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/SingleFileEvent.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/SingleFileEvent.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Event for processing a single file.
  * <p>
- * ATTENTION: This class need to match the one in the dispatch-service.
+ * ATTENTION: This class needs to match the one in the dispatch-service.
  *
  * @param useCase The use case of the event.
  * @param file The file to process.

--- a/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/SingleFileEvent.java
+++ b/handler-core/src/main/java/de/muenchen/oss/swim/libs/handlercore/domain/model/SingleFileEvent.java
@@ -5,17 +5,24 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 /**
  * Event for processing a single file.
  * <p>
  * ATTENTION: This class need to match the one in the dispatch-service.
  *
  * @param useCase The use case of the event.
- * @param presignedFile The file to process.
+ * @param file The file to process.
  */
 public record SingleFileEvent(
         @NotBlank String useCase,
-        @JsonUnwrapped @NotNull @Valid PresignedFile presignedFile) implements FileEvent {
+        @JsonUnwrapped @NotNull @Valid PresignedFile file) implements FileEvent {
 
     public static final String TYPE_NAME = "single";
+
+    @Override
+    public List<PresignedFile> files() {
+        return List.of(file);
+    }
 }


### PR DESCRIPTION
**Description**

- refact(handler,dispatcher): replace FileEvent helper methods to prevent mapping each event to an MultiFileEvent
  - this can change the type of the outgoing event



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized file event handling so both single-file and multi-file events expose files consistently.
  * Improved processing of events containing multiple files by handling each file individually.
  * Preserved use-case information throughout event processing.

* **Bug Fixes**
  * Improved completion and error reporting for file events, including dead-letter processing, by ensuring every file is handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->