### PR TITLE
docs(dispatcher): multi event

### DIFF
--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -109,7 +109,7 @@ To allow a preceding system to change the routing behaviour there is the propert
 
 ## Multi Events
 
-Files matching the pattern `-\d+v\d+$` (e.g. `-1v3.pdf`) are grouped into a single event for joint processing.
+Filenames (without extension) matching the pattern `-\d+v\d+$` (e.g. `...-1v3.pdf`) are grouped into a single event for joint processing.
 This leads to two different types of events, which are determined by the `swim_event_type` header in the Kafka messages:
 - `single`: For processing a single file (for backwards compatibility, events without that header are handled as single events).
 - `multi`: For processing multiple files together (e.g. after splitting a file, where the chunks still belong to the same context).

--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -111,7 +111,7 @@ To allow a preceding system to change the routing behaviour there is the propert
 
 Files matching the pattern `-\d+v\d+$` (e.g. `-1v3.pdf`) are grouped into a single event for joint processing.
 This leads to two different types of events, which are determined by the `swim_event_type` header in the Kafka messages:
-- `single`: For processing a single file (for backwarts compatibility events without that header are handled as single events).
-- `multi`: For processing multiple files together (e.g. after splitting a file, where the junks still belong to the same context).
+- `single`: For processing a single file (for backwards compatibility, events without that header are handled as single events).
+- `multi`: For processing multiple files together (e.g. after splitting a file, where the chunks still belong to the same context).
 
-The [handler-core](../handler-core) has two different interface methods to allow application to handle the different types differently or only support one.
+The [handler-core](../handler-core) has two different interface methods to allow an application to handle the different types differently or support only one.

--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -46,7 +46,7 @@ swim:
     access-key:
     secret-key:
   # file chunking
-  max-file-chunk-age: 1d # after which file age an error should be thrown if file chunks are missing
+  max-file-chunk-age: 1d # after which file age an error should be thrown if file chunks are missing, see section "Multi Events"
   # dirs
   dispatch-folder: inProcess # subfolder to search for files to process under
   finished-folder: finished # subfolder to move finished files to
@@ -109,9 +109,16 @@ To allow a preceding system to change the routing behaviour there is the propert
 
 ## Multi Events
 
-Filenames (without extension) matching the pattern `-\d+v\d+$` (e.g. `...-1v3.pdf`) are grouped into a single event for joint processing.
+Filenames (without extension) matching the pattern `-(\d+)v(\d+)$` (e.g. `...-1v3.pdf`) are grouped into a single event for joint processing.
 This leads to two different types of events, which are determined by the `swim_event_type` header in the Kafka messages:
 - `single`: For processing a single file (for backwards compatibility, events without that header are handled as single events).
 - `multi`: For processing multiple files together (e.g. after splitting a file, where the chunks still belong to the same context).
 
-The [handler-core](../handler-core) has two different interface methods to allow an application to handle the different types differently or support only one.
+During dispatching the group of files in multi events is validated for completeness. 
+This is done by extracting the index (1. matching group) and the junk count (2. matching group) from the above pattern and 
+validating that each junk is present before dispatching the event.
+To prevent errors from occurring when file junks are still uploaded, there is a configurable delay `max-file-chunk-age` (see [Configuration](#configuration)), 
+after which missing junks lead to an error.
+
+For handling these events the [handler-core](../handler-core) has two different interface methods, 
+which allow an application to handle the different types differently or support only one.

--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -106,3 +106,12 @@ To allow a preceding system to change the routing behaviour there is the propert
 - `dispatch` (default if action tag not set): Default routing behaviour
 - `reroute`: Reroute a message to another use case. Target use case is resolved via `swim.dispatch-action-destination-tag-key`
 - `delete`, `ignore`: File is marked as finished without further processing
+
+## Multi Events
+
+Files matching the pattern `-\d+v\d+$` (e.g. `-1v3.pdf`) are grouped into a single event for joint processing.
+This leads to two different types of events, which are determined by the `swim_event_type` header in the Kafka messages:
+- `single`: For processing a single file (for backwarts compatibility events without that header are handled as single events).
+- `multi`: For processing multiple files together (e.g. after splitting a file, where the junks still belong to the same context).
+
+The [handler-core](../handler-core) has two different interface methods to allow application to handle the different types differently or only support one.


### PR DESCRIPTION
**Description**

- docs(dispatcher): multi event


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance for handling “Multi Events,” including clearer filename-matching rules and backward compatibility wording.
  * Added an explanation of how multi-event groups are validated for completeness (via captured index and junk count).
  * Documented the `swim.max-file-chunk-age` delay behavior, including that missing chunks will result in an error after the configured time.
  * Reconfirmed the handler interface supports separate handling for `single` vs `multi` events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->