### PR TITLE
fix(dispatcher): define s3 timeout

### DIFF
--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -45,6 +45,7 @@ swim:
     url:
     access-key:
     secret-key:
+    presigned-url-expiry: 7d
     connection-timeout: 30s
     read-timeout: 60s
     write-timeout: 60s

--- a/dispatch-service/README.md
+++ b/dispatch-service/README.md
@@ -45,6 +45,9 @@ swim:
     url:
     access-key:
     secret-key:
+    connection-timeout: 30s
+    read-timeout: 60s
+    write-timeout: 60s
   # file chunking
   max-file-chunk-age: 1d # after which file age an error should be thrown if file chunks are missing
   # dirs

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -25,6 +25,7 @@ import io.minio.SetObjectTagsArgs;
 import io.minio.StatObjectArgs;
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.MinioException;
+import io.minio.http.HttpUtils;
 import io.minio.http.Method;
 import io.minio.messages.Item;
 import java.io.BufferedReader;
@@ -76,6 +77,10 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
         this.minioClient = MinioClient.builder()
                 .endpoint(s3Properties.getUrl())
                 .credentials(s3Properties.getAccessKey(), s3Properties.getSecretKey())
+                .httpClient(HttpUtils.newDefaultHttpClient(
+                        s3Properties.getConnectionTimeout().toMillis(),
+                        s3Properties.getReadTimeout().toMillis(),
+                        s3Properties.getWriteTimeout().toMillis()))
                 .build();
         this.swimDispatcherProperties = swimDispatcherProperties;
     }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -199,7 +199,7 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
                 .bucket(fileReference.bucket())
                 .object(fileReference.path())
                 .method(Method.GET)
-                .expiry(s3Properties.getPresignedUrlExpiry())
+                .expiry((int) s3Properties.getPresignedUrlExpiry().toSeconds())
                 .build();
         try {
             return minioClient.getPresignedObjectUrl(getPresignedObjectUrlArgs);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Adapter.java
@@ -79,8 +79,8 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
                 .credentials(s3Properties.getAccessKey(), s3Properties.getSecretKey())
                 .httpClient(HttpUtils.newDefaultHttpClient(
                         s3Properties.getConnectionTimeout().toMillis(),
-                        s3Properties.getReadTimeout().toMillis(),
-                        s3Properties.getWriteTimeout().toMillis()))
+                        s3Properties.getWriteTimeout().toMillis(),
+                        s3Properties.getReadTimeout().toMillis()))
                 .build();
         this.swimDispatcherProperties = swimDispatcherProperties;
     }
@@ -199,7 +199,7 @@ public class S3Adapter implements FileSystemOutPort, ReadProtocolOutPort {
                 .bucket(fileReference.bucket())
                 .object(fileReference.path())
                 .method(Method.GET)
-                .expiry((int) s3Properties.getPresignedUrlExpiry().toSeconds())
+                .expiry(Math.toIntExact(s3Properties.getPresignedUrlExpiry().toSeconds()))
                 .build();
         try {
             return minioClient.getPresignedObjectUrl(getPresignedObjectUrlArgs);

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
@@ -28,6 +29,7 @@ class S3Properties {
     @NotNull
     @DurationUnit(ChronoUnit.SECONDS)
     @DurationMin(hours = 1)
+    @DurationMax(days = 7)
     private Duration presignedUrlExpiry = Duration.ofDays(7);
     /**
      * Timeout for connecting to S3.

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
@@ -20,4 +20,22 @@ class S3Properties {
      */
     @NotNull
     private int presignedUrlExpiry = 7 * 24 * 60 * 60;
+    /**
+     * Timeout for connecting to S3.
+     * Default: 30s
+     */
+    @NotNull
+    private Duration connectionTimeout = Duration.ofSeconds(30);
+    /**
+     * Timeout for reading from S3.
+     * Default: 60s
+     */
+    @NotNull
+    private Duration readTimeout = Duration.ofSeconds(60);
+    /**
+     * Timeout for writing to S3.
+     * Default: 60s
+     */
+    @NotNull
+    private Duration writeTimeout = Duration.ofSeconds(60);
 }

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
@@ -2,6 +2,7 @@ package de.muenchen.oss.swim.dispatcher.adapter.out.s3;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -19,7 +20,7 @@ class S3Properties {
      * Default: 7d
      */
     @NotNull
-    private int presignedUrlExpiry = 7 * 24 * 60 * 60;
+    private Duration presignedUrlExpiry = Duration.ofDays(7);
     /**
      * Timeout for connecting to S3.
      * Default: 30s

--- a/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
+++ b/dispatch-service/src/main/java/de/muenchen/oss/swim/dispatcher/adapter/out/s3/S3Properties.java
@@ -3,11 +3,16 @@ package de.muenchen.oss.swim.dispatcher.adapter.out.s3;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.validation.annotation.Validated;
 
 @Data
 @ConfigurationProperties("swim.s3")
+@Validated
 class S3Properties {
     @NotBlank
     private String url;
@@ -16,27 +21,33 @@ class S3Properties {
     @NotBlank
     private String secretKey;
     /**
-     * Time in seconds after which the created presigned urls expire.
+     * Time after which the created presigned urls expire.
+     * Numeric configuration values are interpreted as seconds.
      * Default: 7d
      */
     @NotNull
+    @DurationUnit(ChronoUnit.SECONDS)
+    @DurationMin(hours = 1)
     private Duration presignedUrlExpiry = Duration.ofDays(7);
     /**
      * Timeout for connecting to S3.
      * Default: 30s
      */
     @NotNull
+    @DurationMin(seconds = 1)
     private Duration connectionTimeout = Duration.ofSeconds(30);
     /**
      * Timeout for reading from S3.
      * Default: 60s
      */
     @NotNull
+    @DurationMin(seconds = 1)
     private Duration readTimeout = Duration.ofSeconds(60);
     /**
      * Timeout for writing to S3.
      * Default: 60s
      */
     @NotNull
+    @DurationMin(seconds = 1)
     private Duration writeTimeout = Duration.ofSeconds(60);
 }


### PR DESCRIPTION
**Description**

- fix(dispatcher); set s3 timeout to prevent default 5m to collide with poll timeout
- feat(dispatcher): make s3 timeout configurable
- refact(dispatcher): use Duration for presigned URL lifetime

**Reference**

Issue CCEA-1619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable S3 connection, read, and write timeouts.
  * Presigned URL expiry is now configurable with a seven-day default.
  * S3 timeout and expiry settings support human-readable duration inputs and validation.
  * Improved handling of S3 HTTP connection settings for more predictable request behavior.
* **Documentation**
  * Updated S3 configuration documentation to include presigned URL expiry and connection, read, and write timeout settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->