### PR TITLE
chore: downgrade spring-cloud to 2025.1.1 and rm from matching

### DIFF
--- a/dipa-service/pom.xml
+++ b/dipa-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/dipa-service/pom.xml
+++ b/dipa-service/pom.xml
@@ -25,7 +25,7 @@
 
         <!-- Core Frameworks -->
         <swim-handler-core.version>2.0.0</swim-handler-core.version>
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
+        <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
 
         <!-- Linting & Formatting -->
         <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>

--- a/dispatch-service/pom.xml
+++ b/dispatch-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/dispatch-service/pom.xml
+++ b/dispatch-service/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <!-- Core Frameworks -->
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
+        <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
 
         <!-- Other -->
         <minio.version>8.5.17</minio.version>

--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <!-- Core Frameworks -->
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
+        <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
         <swim-handler-core.version>2.0.0</swim-handler-core.version>
         <refarch-dms-integration-fabasoft-rest-api.version>4.0.0</refarch-dms-integration-fabasoft-rest-api.version>
 

--- a/dms-service/pom.xml
+++ b/dms-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/handler-core/pom.xml
+++ b/handler-core/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <!-- Core Frameworks -->
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
+        <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
 
         <!-- Linting & Formatting -->
         <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>

--- a/handler-core/pom.xml
+++ b/handler-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/invoice-service/pom.xml
+++ b/invoice-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/invoice-service/pom.xml
+++ b/invoice-service/pom.xml
@@ -25,7 +25,7 @@
 
         <!-- Core Frameworks -->
         <swim-handler-core.version>2.0.0</swim-handler-core.version>
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
+        <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
 
         <!-- Linting & Formatting -->
         <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>

--- a/matching-service/pom.xml
+++ b/matching-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/matching-service/pom.xml
+++ b/matching-service/pom.xml
@@ -24,7 +24,6 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <!-- Core Frameworks -->
-        <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version> <!-- Must match the chosen Spring Boot version -->
         <refarch-tools.version>1.3.0</refarch-tools.version>
         <refarch-dms-integration-fabasoft-rest-api.version>4.0.0</refarch-dms-integration-fabasoft-rest-api.version>
 
@@ -58,23 +57,7 @@
         <p2.mirror>download.eclipse.org</p2.mirror>
     </properties>
 
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Import dependency management from Spring Cloud -->
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-
     <dependencies>
-
         <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -84,4 +84,3 @@ info:
     description: @project.description@
   build:
     java.version: @java.version@
-    spring-cloud.version: @spring-cloud-dependencies.version@

--- a/matching-service/src/main/resources/banner.txt
+++ b/matching-service/src/main/resources/banner.txt
@@ -4,7 +4,6 @@ ${spring.application.name} (${spring.application.group})
 Application Version    : ${info.application.version}
 Java Version           : ${info.build.java.version}
 Spring Boot Version    : ${spring-boot.version}
-Spring Cloud Version   : ${info.build.spring-cloud.version}
 Active Spring Profiles : ${spring.profiles.active:}
 About                  : ${info.application.description}
 


### PR DESCRIPTION
**Description**

- chore: downgrade to spring-cloud 2025.1.1
  - https://github.com/spring-cloud/spring-cloud-stream/issues/3203 was introduced in 2025.1.2 and should be fixed in 2025.1.3
  - downgrade to spring 4.0.x for compatibility

According log
```
{"@timestamp":"2026-07-31T08:18:31.342298215+02:00","@version":"1","message":"org.springframework.messaging.MessagingException\n\tat org.springframework.integration.endpoint.AbstractPollingEndpoint.pollForMessage(AbstractPollingEndpoint.java:441)\n\tat org.springframework.integration.endpoint.AbstractPollingEndpoint.lambda$createPoller$1(AbstractPollingEndpoint.java:357)\n\tat org.springframework.integration.util.ErrorHandlingTaskExecutor.lambda$execute$0(ErrorHandlingTaskExecutor.java:64)\n\tat org.springframework.core.task.SyncTaskExecutor.execute(SyncTaskExecutor.java:88)\n\tat org.springframework.integration.util.ErrorHandlingTaskExecutor.execute(ErrorHandlingTaskExecutor.java:62)\n\tat org.springframework.integration.endpoint.AbstractPollingEndpoint.lambda$createPoller$0(AbstractPollingEndpoint.java:350)\n\tat org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)\n\tat org.springframework.scheduling.concurrent.ReschedulingRunnable.run(ReschedulingRunnable.java:94)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)\n\tat java.base/java.lang.Thread.run(Thread.java:1583)\nCaused by: java.lang.ClassCastException: class org.springframework.cloud.stream.messaging.DirectWithAttributesChannel$$SpringCGLIB$$0 cannot be cast to class java.util.function.Supplier (org.springframework.cloud.stream.messaging.DirectWithAttributesChannel$$SpringCGLIB$$0 is in unnamed module of loader org.springframework.boot.loader.launch.LaunchedClassLoader @16b98e56; java.util.function.Supplier is in module java.base of loader 'bootstrap')\n\tat org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.doApply(SimpleFunctionRegistry.java:826)\n\tat org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.apply(SimpleFunctionRegistry.java:656)\n\tat org.springframework.cloud.function.context.catalog.FunctionAroundWrapper.apply(FunctionAroundWrapper.java:52)\n\tat org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.apply(SimpleFunctionRegistry.java:653)\n\tat org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.get(SimpleFunctionRegistry.java:664)\n\tat org.springframework.cloud.stream.function.PartitionAwareFunctionWrapper.get(PartitionAwareFunctionWrapper.java:111)\n\tat org.springframework.integration.dsl.IntegrationFlow$1.doReceive(IntegrationFlow.java:256)\n\tat org.springframework.integration.endpoint.AbstractMessageSource.receive(AbstractMessageSource.java:139)\n\tat org.springframework.integration.endpoint.SourcePollingChannelAdapter.receiveMessage(SourcePollingChannelAdapter.java:255)\n\tat org.springframework.integration.endpoint.AbstractPollingEndpoint.doPoll(AbstractPollingEndpoint.java:459)\n\tat org.springframework.integration.endpoint.AbstractPollingEndpoint.pollForMessage(AbstractPollingEndpoint.java:421)\n\t... 13 more\n","logger_name":"org.springframework.integration.handler.LoggingHandler","thread_name":"scheduling-1","level":"ERROR","level_value":40000,"tags":["COMMONS-LOGGING"],"application_name":"dispatch-service","application_group":"de.muenchen.oss.swim"}
```

**Reference**

Upgraded to 2025.1.2 within https://github.com/it-at-m/swim/pull/405 and #403
DBS fixed that with https://github.com/it-at-m/dbs/pull/616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the application platform versions across services for improved consistency.
  * Simplified service configuration by removing obsolete framework version references.
  * Removed outdated framework version details from the application startup display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->