### PR TITLE
fix(dms): kubernetes colliding apiClient bean

### DIFF
--- a/dms-service/src/main/java/de/muenchen/oss/swim/dms/adapter/out/dms/ApiClientConfiguration.java
+++ b/dms-service/src/main/java/de/muenchen/oss/swim/dms/adapter/out/dms/ApiClientConfiguration.java
@@ -20,7 +20,7 @@ import reactor.netty.http.client.HttpClient;
 @Configuration
 class ApiClientConfiguration {
     @Bean
-    protected ApiClient apiClient(final DmsProperties dmsProperties) {
+    protected ApiClient dmsApiClient(final DmsProperties dmsProperties) {
         final HttpClient httpClient = HttpClient.create()
                 .responseTimeout(dmsProperties.getReadTimeout())
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
@@ -36,47 +36,47 @@ class ApiClientConfiguration {
     }
 
     @Bean
-    protected ObjectAndImportToInboxApi objectAndImportToInboxApi(final ApiClient apiClient) {
-        return new ObjectAndImportToInboxApi(apiClient);
+    protected ObjectAndImportToInboxApi objectAndImportToInboxApi(final ApiClient dmsApiClient) {
+        return new ObjectAndImportToInboxApi(dmsApiClient);
     }
 
     @Bean
-    protected IncomingsApi incomingsApi(final ApiClient apiClient) {
-        return new IncomingsApi(apiClient);
+    protected IncomingsApi incomingsApi(final ApiClient dmsApiClient) {
+        return new IncomingsApi(dmsApiClient);
     }
 
     @Bean
-    protected ProceduresApi proceduresApi(final ApiClient apiClient) {
-        return new ProceduresApi(apiClient);
+    protected ProceduresApi proceduresApi(final ApiClient dmsApiClient) {
+        return new ProceduresApi(dmsApiClient);
     }
 
     @Bean
-    protected ProcedureObjectsApi procedureObjectsApi(final ApiClient apiClient) {
-        return new ProcedureObjectsApi(apiClient);
+    protected ProcedureObjectsApi procedureObjectsApi(final ApiClient dmsApiClient) {
+        return new ProcedureObjectsApi(dmsApiClient);
     }
 
     @Bean
-    protected ContentObjectsApi contentObjectsApi(final ApiClient apiClient) {
-        return new ContentObjectsApi(apiClient);
+    protected ContentObjectsApi contentObjectsApi(final ApiClient dmsApiClient) {
+        return new ContentObjectsApi(dmsApiClient);
     }
 
     @Bean
-    protected SearchObjNamesApi searchObjNamesApi(final ApiClient apiClient) {
-        return new SearchObjNamesApi(apiClient);
+    protected SearchObjNamesApi searchObjNamesApi(final ApiClient dmsApiClient) {
+        return new SearchObjNamesApi(dmsApiClient);
     }
 
     @Bean
-    protected IncomingFromInboxApi incomingFromInboxApi(final ApiClient apiClient) {
-        return new IncomingFromInboxApi(apiClient);
+    protected IncomingFromInboxApi incomingFromInboxApi(final ApiClient dmsApiClient) {
+        return new IncomingFromInboxApi(dmsApiClient);
     }
 
     @Bean
-    protected DepositObjectsApi depositObjectsApi(final ApiClient apiClient) {
-        return new DepositObjectsApi(apiClient);
+    protected DepositObjectsApi depositObjectsApi(final ApiClient dmsApiClient) {
+        return new DepositObjectsApi(dmsApiClient);
     }
 
     @Bean
-    protected SubjectAreasApi subjectAreasApi(final ApiClient apiClient) {
-        return new SubjectAreasApi(apiClient);
+    protected SubjectAreasApi subjectAreasApi(final ApiClient dmsApiClient) {
+        return new SubjectAreasApi(dmsApiClient);
     }
 }


### PR DESCRIPTION
**Description**

- fix(dms): kubernetes apiClient bean colliding with Dms

```
{"@timestamp":"2026-08-20T09:43:26.890061871+02:00","@version":"1","message":"\n\n***************************\nAPPLICATION FAILED TO START\n***************************\n\nDescription:\n\nThe bean 'apiClient', defined in class path resource [org/springframework/cloud/kubernetes/client/KubernetesClientAutoConfiguration.class], could not be registered. A bean with that name has already been defined in class path resource [de/muenchen/oss/swim/dms/adapter/out/dms/ApiClientConfiguration.class] and overriding is disabled.\n\nAction:\n\nConsider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true\n","logger_name":"org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter","thread_name":"main","level":"ERROR","level_value":40000,"tags":["COMMONS-LOGGING"],"application_name":"dms-service","application_group":"de.muenchen.oss.swim"}
```

**Reference**

Introduced with #427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal DMS API client configuration naming while preserving existing behavior, construction, and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->